### PR TITLE
 fix: Fix XML download 400 error and correct file extension

### DIFF
--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -38,7 +38,7 @@ class WorkItem:
             authors=data.get("authorships"),
             type=data.get("type"),
             has_pdf=has_content.get("pdf", False),
-            has_xml=has_content.get("tei_xml", False),
+            has_xml=has_content.get("grobid_xml", False),
             raw_data=data,
         )
 
@@ -148,7 +148,7 @@ class OpenAlexAPIClient:
             content_filter = (
                 "has_content.pdf:true"
                 if content_format in (ContentFormat.PDF, ContentFormat.BOTH)
-                else "has_content.tei_xml:true"
+                else "has_content.grobid_xml:true"
             )
             if filter_str:
                 full_filter = f"{content_filter},{filter_str}"

--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -194,7 +194,8 @@ class OpenAlexAPIClient:
         session = await self._get_session()
 
         # Determine file extension
-        ext = "pdf" if content_format == ContentFormat.PDF else "tei.xml"
+        # OpenAlex Content API uses .grobid-xml for TEI XML content
+        ext = "pdf" if content_format == ContentFormat.PDF else "grobid-xml"
         url = f"{self.CONTENT_API_BASE}/works/{work_id}.{ext}"
 
         try:

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -365,10 +365,10 @@ class DownloadOrchestrator:
 
                     if result.success and result.content:
                         # Save content
-                        ext = "pdf" if fmt == ContentFormat.PDF else "tei.xml"
+                        ext = "pdf" if fmt == ContentFormat.PDF else "xml.gz"
                         path = str(work_id_to_path(filename_base, ext, nested=self.config.nested))
                         content_type = (
-                            "application/pdf" if fmt == ContentFormat.PDF else "application/xml"
+                            "application/pdf" if fmt == ContentFormat.PDF else "application/gzip"
                         )
                         await self.storage.save(path, result.content, content_type)
 


### PR DESCRIPTION
## Description
This PR fixes a bug where downloading XML content fails with a `400 Bad Request` error due to an invalid API filter. It also corrects the file extension for downloaded XML files to properly reflect that they are gzip-compressed.

## Context
- The filter `has_content.tei_xml` is no longer valid in the OpenAlex API and has been replaced by `has_content.grobid_xml` (see [documentation](https://docs.openalex.org/api-entities/works/work-object#has_content)).
- The downloaded XML content is gzipped, but the previous implementation incorrectly saved it with a plain `.xml` extension.

## Changes
- **Update API Filter**: Replaced `has_content.tei_xml` with `has_content.grobid_xml` in the API client.
- **Correct Download URL**: Updated the content URL construction to use the `.grobid-xml` extension.
- **Fix File Extension**: Changed the output file extension to `.xml.gz` to match the actual file format.

## Steps to Reproduce
Run the following command to attempt an XML download:

```bash
openalex download \
  --api-key <YOUR_API_KEY> \
  --output ./papers \
  --filter "primary_location.source.id:S2764890288" \
  --content xml
```

**Result:**
- **Before:** Fails with a `400 Bad Request` error complaining about `tei_xml`.
- **After:** Successfully downloads works with the correct `.xml.gz` extension.