### PR TITLE
fix: Fix Error on windows 11: "NotImplementedError" in asyncio

### DIFF
--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import signal
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -87,7 +88,10 @@ class DownloadOrchestrator:
         # Set up signal handlers for graceful shutdown
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, self._request_shutdown)
+            if sys.platform == "win32":
+                signal.signal(sig, self._handle_windows_request_shutdown)
+            else:
+                loop.add_signal_handler(sig, self._request_shutdown)
 
         try:
             # Initialize or resume checkpoint
@@ -145,7 +149,10 @@ class DownloadOrchestrator:
 
             # Remove signal handlers
             for sig in (signal.SIGINT, signal.SIGTERM):
-                loop.remove_signal_handler(sig)
+                if sys.platform == "win32":
+                    signal.signal(sig, signal.SIG_DFL)
+                else:
+                    loop.remove_signal_handler(sig)
 
     def _request_shutdown(self) -> None:
         """Handle shutdown signal."""
@@ -157,6 +164,10 @@ class DownloadOrchestrator:
             self.progress_tracker.log_warning(
                 "Shutdown requested. Finishing current downloads..."
             )
+
+    def _handle_windows_request_shutdown(self, *args, **kwargs) -> None:
+        """Handle shutdown signal on Windows."""
+        self._request_shutdown()
 
     def _handle_credits_exhausted(self) -> None:
         """Stop all work when credits are exhausted."""


### PR DESCRIPTION
### Description

This PR fixes #2 a bug that caused a `NotImplementedError` exception to occur when launching the CLI on Windows, as the `asyncio.events.AbstractEventLoop.add_signal_handler` method is not supported on Windows.

---

### Context

The `ProctorEventLoop` implementation of the event loop used on Windows does not support the `add_signal_handler` method. This method works only on POSIX-compliant systems.

---

### Changes

- **Update the signal handler setup and removal:** Added platform check with implementation of Windows-compatible signal handling via the `signal` module.
- **Add a wrapper method:** Added the `_handle_windows_request_shutdown` wrapper method to ensure consistency during static type checking.

---

### Steps to Reproduce

Run the following command to attempt to launch the CLI on Windows:

```
openalex download \
  --api-key YOUR_API_KEY \
  --output ./results \
  --filter "topics.id:T10325"
```

**Result:**

- **Before:** Fails with a `NotImplementedError` exception complaining about `add_signal_handler`.
- **After:** Successfully runs on Windows.