### PR TITLE
Retry transient 429s and fail works correctly

### DIFF
--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -136,6 +136,8 @@ class OpenAlexAPIClient:
         filter_str: str | None = None,
         content_format: ContentFormat = ContentFormat.NONE,
         cursor: str = "*",
+        max_attempts: int = 3,
+        base_delay_seconds: float = 1.0,
     ) -> AsyncIterator[tuple[list[WorkItem], str | None]]:
         """
         List works using cursor pagination.
@@ -172,22 +174,31 @@ class OpenAlexAPIClient:
                 params["filter"] = full_filter
             url = f"{self.WORKS_API_BASE}/works"
 
-            async with session.get(url, params=params) as response:
-                if response.status == 429:
-                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
-                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
-                    if remaining < credits_required:
-                        raise CreditsExhaustedError(
-                            "Insufficient credits. Credits reset daily at midnight UTC."
+            attempt = 0
+            while True:
+                attempt += 1
+                async with session.get(url, params=params) as response:
+                    if response.status == 429:
+                        remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                        credits_required = int(
+                            response.headers.get("X-RateLimit-Credits-Required", 1)
                         )
-                    raise aiohttp.ClientResponseError(
-                        response.request_info,
-                        response.history,
-                        status=429,
-                        message="Rate limited",
-                    )
-                response.raise_for_status()
-                data = await response.json()
+                        if remaining < credits_required:
+                            raise CreditsExhaustedError(
+                                "Insufficient credits. Credits reset daily at midnight UTC."
+                            )
+                        if attempt >= max_attempts:
+                            raise aiohttp.ClientResponseError(
+                                response.request_info,
+                                response.history,
+                                status=429,
+                                message="Rate limited",
+                            )
+                        await asyncio.sleep(base_delay_seconds * (2 ** (attempt - 1)))
+                        continue
+                    response.raise_for_status()
+                    data = await response.json()
+                    break
 
             results = data.get("results", [])
             works = [WorkItem.from_api_response(r) for r in results]
@@ -207,6 +218,8 @@ class OpenAlexAPIClient:
         seed: int | None = None,
         filter_str: str | None = None,
         content_format: ContentFormat = ContentFormat.NONE,
+        max_attempts: int = 3,
+        base_delay_seconds: float = 1.0,
     ) -> AsyncIterator[list[WorkItem]]:
         """
         List a random sample of works using page-based pagination.
@@ -254,22 +267,31 @@ class OpenAlexAPIClient:
 
             url = f"{self.WORKS_API_BASE}/works"
 
-            async with session.get(url, params=params) as response:
-                if response.status == 429:
-                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
-                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
-                    if remaining < credits_required:
-                        raise CreditsExhaustedError(
-                            "Insufficient credits. Credits reset daily at midnight UTC."
+            attempt = 0
+            while True:
+                attempt += 1
+                async with session.get(url, params=params) as response:
+                    if response.status == 429:
+                        remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                        credits_required = int(
+                            response.headers.get("X-RateLimit-Credits-Required", 1)
                         )
-                    raise aiohttp.ClientResponseError(
-                        response.request_info,
-                        response.history,
-                        status=429,
-                        message="Rate limited",
-                    )
-                response.raise_for_status()
-                data = await response.json()
+                        if remaining < credits_required:
+                            raise CreditsExhaustedError(
+                                "Insufficient credits. Credits reset daily at midnight UTC."
+                            )
+                        if attempt >= max_attempts:
+                            raise aiohttp.ClientResponseError(
+                                response.request_info,
+                                response.history,
+                                status=429,
+                                message="Rate limited",
+                            )
+                        await asyncio.sleep(base_delay_seconds * (2 ** (attempt - 1)))
+                        continue
+                    response.raise_for_status()
+                    data = await response.json()
+                    break
 
             results = data.get("results", [])
             works = [WorkItem.from_api_response(r) for r in results]

--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -174,12 +174,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -241,6 +237,7 @@ class OpenAlexAPIClient:
                 full_filter = content_filter
 
         import math
+
         total_pages = math.ceil(sample_size / self.per_page)
 
         for page in range(1, total_pages + 1):
@@ -259,12 +256,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -319,12 +312,8 @@ class OpenAlexAPIClient:
                     )
 
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 0)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 0))
                     is_exhausted = remaining < credits_required
                     return DownloadResult(
                         work_id=work_id,
@@ -409,12 +398,8 @@ class OpenAlexAPIClient:
             if response.status == 404:
                 raise Exception(f"Work not found: {work_id}")
             if response.status == 429:
-                remaining = int(
-                    response.headers.get("X-RateLimit-Remaining", 0)
-                )
-                credits_required = int(
-                    response.headers.get("X-RateLimit-Credits-Required", 1)
-                )
+                remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                 if remaining < credits_required:
                     raise CreditsExhaustedError(
                         "Insufficient credits. Credits reset daily at midnight UTC."
@@ -427,6 +412,30 @@ class OpenAlexAPIClient:
                 )
             response.raise_for_status()
             return await response.json()
+
+    async def get_work_metadata_with_retry(
+        self,
+        work_id: str,
+        max_attempts: int = 3,
+        base_delay_seconds: float = 1.0,
+    ) -> dict:
+        """
+        Fetch full work metadata from the singleton API with bounded retry.
+
+        Retries HTTP 429 responses using a simple exponential backoff.
+        Credits exhaustion is treated as fatal and is not retried.
+        """
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                return await self.get_work_metadata(work_id)
+            except CreditsExhaustedError:
+                raise
+            except aiohttp.ClientResponseError as exc:
+                if exc.status != 429 or attempt >= max_attempts:
+                    raise
+                await asyncio.sleep(base_delay_seconds * (2 ** (attempt - 1)))
 
     async def resolve_dois(self, dois: list[str]) -> dict[str, str]:
         """

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -111,8 +111,7 @@ class DownloadOrchestrator:
 
             # Start worker tasks
             workers = [
-                asyncio.create_task(self._download_worker(i))
-                for i in range(self.config.workers)
+                asyncio.create_task(self._download_worker(i)) for i in range(self.config.workers)
             ]
 
             # Start result processor
@@ -154,9 +153,7 @@ class DownloadOrchestrator:
             raise KeyboardInterrupt()
         self._shutdown_requested = True
         if self.progress_tracker:
-            self.progress_tracker.log_warning(
-                "Shutdown requested. Finishing current downloads..."
-            )
+            self.progress_tracker.log_warning("Shutdown requested. Finishing current downloads...")
 
     def _handle_credits_exhausted(self) -> None:
         """Stop all work when credits are exhausted."""
@@ -317,9 +314,7 @@ class DownloadOrchestrator:
                     await self._work_queue.put(work)
 
                 if self.progress_tracker:
-                    self.progress_tracker.log_info(
-                        f"Queued {total_count} works from sample..."
-                    )
+                    self.progress_tracker.log_info(f"Queued {total_count} works from sample...")
 
         except CreditsExhaustedError:
             self._handle_credits_exhausted()
@@ -344,12 +339,23 @@ class DownloadOrchestrator:
 
             try:
                 # Fetch work metadata from singleton API
-                metadata = await self.api_client.get_work_metadata(work_id)
+                metadata = await self.api_client.get_work_metadata_with_retry(work_id)
                 work = WorkItem.from_api_response(metadata)
                 await self._work_queue.put(work)
+            except CreditsExhaustedError:
+                self._handle_credits_exhausted()
+                break
             except Exception as e:
                 if self.progress_tracker:
                     self.progress_tracker.log_error(f"Error fetching metadata for {work_id}: {e}")
+                await self._results_queue.put(
+                    DownloadResult(
+                        work_id=work_id,
+                        format=ContentFormat.NONE,
+                        success=False,
+                        error=f"Failed to fetch metadata: {e}",
+                    )
+                )
 
     async def _download_worker(self, worker_id: int) -> None:
         """Worker that downloads metadata and optionally content."""
@@ -374,21 +380,24 @@ class DownloadOrchestrator:
                     filename_base = doi_to_filename(orig)
 
             # Always save full metadata (fetch from singleton API)
+            meta_content = b""
             try:
-                full_metadata = await self.api_client.get_work_metadata(work.work_id)
-                meta_path = str(
-                    work_id_to_path(filename_base, "json", nested=self.config.nested)
-                )
+                full_metadata = await self.api_client.get_work_metadata_with_retry(work.work_id)
+                meta_path = str(work_id_to_path(filename_base, "json", nested=self.config.nested))
                 meta_content = json.dumps(full_metadata, indent=2).encode()
                 await self.storage.save(meta_path, meta_content, "application/json")
             except CreditsExhaustedError:
                 self._handle_credits_exhausted()
                 break
             except Exception as e:
-                if self.progress_tracker:
-                    self.progress_tracker.log_warning(
-                        f"Failed to fetch metadata for {work.work_id}: {e}"
-                    )
+                result = DownloadResult(
+                    work_id=work.work_id,
+                    format=ContentFormat.NONE,
+                    success=False,
+                    error=f"Failed to fetch metadata: {e}",
+                )
+                await self._results_queue.put(result)
+                continue
 
             # If no content requested, we're done with this work
             if self.config.content_format == ContentFormat.NONE:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,55 @@
+"""Tests for API client retry behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import aiohttp
+import pytest
+
+from openalex_cli.api_client import CreditsExhaustedError, OpenAlexAPIClient
+
+
+@pytest.mark.asyncio
+async def test_get_work_metadata_with_retry_retries_429(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    async def fake_get_work_metadata(work_id: str):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=429,
+                message="Rate limited",
+            )
+        return {"id": f"https://openalex.org/{work_id}"}
+
+    async def fake_sleep(_: float):
+        return None
+
+    monkeypatch.setattr(client, "get_work_metadata", fake_get_work_metadata)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    result = await client.get_work_metadata_with_retry("W123", max_attempts=3)
+
+    assert result == {"id": "https://openalex.org/W123"}
+    assert calls["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_get_work_metadata_with_retry_does_not_retry_credits_exhausted(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    async def fake_get_work_metadata(_: str):
+        calls["count"] += 1
+        raise CreditsExhaustedError("Insufficient credits")
+
+    monkeypatch.setattr(client, "get_work_metadata", fake_get_work_metadata)
+
+    with pytest.raises(CreditsExhaustedError):
+        await client.get_work_metadata_with_retry("W123", max_attempts=3)
+
+    assert calls["count"] == 1

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,52 @@
+"""Tests for downloader metadata failure handling."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from openalex_cli.api_client import DownloadResult, WorkItem
+from openalex_cli.downloader import DownloadConfig, DownloadOrchestrator
+from openalex_cli.utils import ContentFormat
+
+
+class DummyCheckpointManager:
+    def is_completed(self, work_id: str) -> bool:
+        return False
+
+
+class DummyStorage:
+    async def save(self, *_args, **_kwargs):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_download_worker_reports_failure_when_metadata_fetch_fails(monkeypatch):
+    config = DownloadConfig(api_key="test", output_path=".", workers=1)
+    orchestrator = DownloadOrchestrator(config)
+
+    async def fake_get_work_metadata_with_retry(_work_id: str):
+        raise Exception("Rate limited")
+
+    monkeypatch.setattr(
+        orchestrator.api_client,
+        "get_work_metadata_with_retry",
+        fake_get_work_metadata_with_retry,
+    )
+
+    orchestrator.storage = DummyStorage()
+    orchestrator.checkpoint_manager = DummyCheckpointManager()
+    orchestrator._work_queue = asyncio.Queue()
+    orchestrator._results_queue = asyncio.Queue()
+    await orchestrator._work_queue.put(WorkItem(work_id="W123"))
+    await orchestrator._work_queue.put(None)
+
+    await orchestrator._download_worker(worker_id=0)
+
+    result = await orchestrator._results_queue.get()
+    assert isinstance(result, DownloadResult)
+    assert result.work_id == "W123"
+    assert result.success is False
+    assert result.format == ContentFormat.NONE
+    assert "Failed to fetch metadata" in (result.error or "")

--- a/tests/test_list_retry.py
+++ b/tests/test_list_retry.py
@@ -1,0 +1,135 @@
+"""Tests for paginated list retry behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import aiohttp
+import pytest
+
+from openalex_cli.api_client import CreditsExhaustedError, OpenAlexAPIClient
+from openalex_cli.utils import ContentFormat
+
+
+@pytest.mark.asyncio
+async def test_list_works_retries_429(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self, status: int, payload: dict, headers: dict[str, str] | None = None):
+            self.status = status
+            self._payload = payload
+            self.headers = headers or {}
+            self.request_info = None
+            self.history = ()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            if self.status >= 400:
+                raise aiohttp.ClientResponseError(
+                    self.request_info,
+                    self.history,
+                    status=self.status,
+                    message="request failed",
+                )
+
+        async def json(self):
+            return self._payload
+
+    class FakeSession:
+        def get(self, url, params=None):
+            calls["count"] += 1
+            if calls["count"] < 3:
+                return FakeResponse(
+                    429,
+                    {},
+                    {"X-RateLimit-Remaining": "10", "X-RateLimit-Credits-Required": "1"},
+                )
+            return FakeResponse(
+                200,
+                {
+                    "results": [
+                        {
+                            "id": "https://openalex.org/W123",
+                            "has_content": {"pdf": False, "grobid_xml": False},
+                        }
+                    ],
+                    "meta": {"next_cursor": None},
+                },
+            )
+
+    async def fake_sleep(_: float):
+        return None
+
+    monkeypatch.setattr(client, "_get_session", lambda: FakeSession())
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    pages = []
+    async for works, next_cursor in client.list_works(
+        filter_str="publication_year:>2020",
+        content_format=ContentFormat.NONE,
+        cursor="*",
+        max_attempts=3,
+        base_delay_seconds=0.01,
+    ):
+        pages.append((works, next_cursor))
+
+    assert calls["count"] == 3
+    assert len(pages) == 1
+    works, next_cursor = pages[0]
+    assert len(works) == 1
+    assert works[0].work_id == "W123"
+    assert next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_list_works_raises_credits_exhausted_without_retry(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self):
+            self.status = 429
+            self.headers = {
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Credits-Required": "1",
+            }
+            self.request_info = None
+            self.history = ()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        async def json(self):
+            return {}
+
+    class FakeSession:
+        def get(self, url, params=None):
+            calls["count"] += 1
+            return FakeResponse()
+
+    monkeypatch.setattr(client, "_get_session", lambda: FakeSession())
+
+    with pytest.raises(CreditsExhaustedError):
+        async for _works, _cursor in client.list_works(
+            filter_str="publication_year:>2020",
+            content_format=ContentFormat.NONE,
+            cursor="*",
+            max_attempts=3,
+            base_delay_seconds=0.01,
+        ):
+            pass
+
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- retry transient `429` responses for singleton metadata fetches
- retry transient `429` responses for paginated work listing (`/works` pages and sample pages)
- use the retrying metadata path in both ID-list production and worker-side metadata saves
- mark a work as failed when metadata still cannot be fetched instead of falling through into a false success result
- add focused tests for metadata retry and paginated listing retry

## Before
There were two separate failure points in the downloader:

1. **Singleton metadata fetches failed immediately on `429`**
   The downloader fetches full work metadata from the singleton works API even for metadata-only runs. Before this change, a metadata `429` raised immediately and the worker could still continue into the metadata-only success path after only logging a warning.

2. **Paginated listing failed immediately on `429`**
   The producer enumerates pages from `/works` using cursor pagination (and sample pages in sample mode). Before this change, a transient `429` during page listing raised immediately and could stop the producer even though retrying the same page request shortly afterward would likely have succeeded.

In practice that meant transient rate limiting could either:
- end a large run earlier than necessary, or
- leave a metadata fetch in an ambiguous state where a failed metadata request could be reported as a completed work.

## After
This change makes the downloader more resilient to transient rate limiting while keeping credits exhaustion fatal:

- Added `get_work_metadata_with_retry()` with bounded retry and exponential backoff for singleton metadata `429`s
- Switched both metadata entrypoints to use the retrying helper:
  - `_produce_work_from_ids()`
  - `_download_worker()`
- If metadata still fails after retry, emit a failed `DownloadResult` and stop processing that work instead of continuing into a false success path
- Added bounded retry with exponential backoff to:
  - `list_works()`
  - `list_works_sample()`
- Credits exhaustion still aborts immediately and is not retried

## Why this design
The goal is to distinguish between:
- **transient throttling**: recover inline and continue the run
- **real exhaustion / unrecoverable failure**: surface the failure accurately

This keeps the downloader simple while making large metadata runs much less brittle.

## Validation
- exercised the metadata retry helper in the live editable install environment with synthetic repeated `429` failures and confirmed success on the third attempt
- exercised a real `openalex download` run end-to-end with forced metadata `429` failures and verified the command completed successfully instead of failing at the first rate-limit response
- exercised paginated listing retry in the live runtime with synthetic repeated `429` page responses and verified the listing path retried and then succeeded