### PR TITLE
Make metadata-only checkpoint resume page-safe

### DIFF
--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import AsyncIterator
+from typing import Any, cast
 
 import aiohttp
 
@@ -61,6 +62,7 @@ class DownloadResult:
     credits_cost: int = 0
     rate_limit_remaining: int | None = None
     file_size: int = 0
+    page_seq: int | None = None
 
 
 @dataclass
@@ -157,10 +159,7 @@ class OpenAlexAPIClient:
                 content_filter = "has_content.pdf:true"
             else:
                 content_filter = "has_content.grobid_xml:true"
-            if filter_str:
-                full_filter = f"{content_filter},{filter_str}"
-            else:
-                full_filter = content_filter
+            full_filter = f"{content_filter},{filter_str}" if filter_str else content_filter
 
         while cursor:
             params = {
@@ -174,12 +173,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -235,12 +230,10 @@ class OpenAlexAPIClient:
                 content_filter = "has_content.pdf:true"
             else:
                 content_filter = "has_content.grobid_xml:true"
-            if filter_str:
-                full_filter = f"{content_filter},{filter_str}"
-            else:
-                full_filter = content_filter
+            full_filter = f"{content_filter},{filter_str}" if filter_str else content_filter
 
         import math
+
         total_pages = math.ceil(sample_size / self.per_page)
 
         for page in range(1, total_pages + 1):
@@ -259,12 +252,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -319,12 +308,8 @@ class OpenAlexAPIClient:
                     )
 
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 0)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 0))
                     is_exhausted = remaining < credits_required
                     return DownloadResult(
                         work_id=work_id,
@@ -385,7 +370,7 @@ class OpenAlexAPIClient:
                 error="Request timed out",
             )
 
-    async def get_work_metadata(self, work_id: str) -> dict:
+    async def get_work_metadata(self, work_id: str) -> dict[str, Any]:
         """
         Fetch full work metadata from singleton API.
 
@@ -409,12 +394,8 @@ class OpenAlexAPIClient:
             if response.status == 404:
                 raise Exception(f"Work not found: {work_id}")
             if response.status == 429:
-                remaining = int(
-                    response.headers.get("X-RateLimit-Remaining", 0)
-                )
-                credits_required = int(
-                    response.headers.get("X-RateLimit-Credits-Required", 1)
-                )
+                remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                 if remaining < credits_required:
                     raise CreditsExhaustedError(
                         "Insufficient credits. Credits reset daily at midnight UTC."
@@ -426,7 +407,7 @@ class OpenAlexAPIClient:
                     message="Rate limited",
                 )
             response.raise_for_status()
-            return await response.json()
+            return cast(dict[str, Any], await response.json())
 
     async def resolve_dois(self, dois: list[str]) -> dict[str, str]:
         """

--- a/src/openalex_cli/checkpoint.py
+++ b/src/openalex_cli/checkpoint.py
@@ -7,6 +7,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from .state_io import atomic_write_json
+
 
 @dataclass
 class DownloadStats:
@@ -109,7 +111,7 @@ class CheckpointManager:
                 data = json.load(f)
             self._checkpoint = Checkpoint.from_dict(data)
             return self._checkpoint
-        except (json.JSONDecodeError, KeyError) as e:
+        except (json.JSONDecodeError, KeyError):
             # Corrupted checkpoint - return None to start fresh
             return None
 
@@ -171,6 +173,37 @@ class CheckpointManager:
         """Check if a work ID has already been completed."""
         return work_id in self.get().completed_work_ids
 
+    def terminal_work_ids(self) -> set[str]:
+        """Return all work IDs with a committed terminal outcome."""
+        checkpoint = self.get()
+        return checkpoint.completed_work_ids | checkpoint.failed_work_ids
+
+    def commit_page(
+        self,
+        cursor: str | None,
+        completed_entries: list[tuple[str, int, int]],
+        failed_work_ids: list[str],
+    ) -> None:
+        """Commit a fully terminal page and advance the durable cursor."""
+        checkpoint = self.get()
+
+        for work_id, file_size, credits in completed_entries:
+            checkpoint.completed_work_ids.add(work_id)
+            checkpoint.failed_work_ids.discard(work_id)
+            checkpoint.stats.total_downloaded += 1
+            checkpoint.stats.total_bytes += file_size
+            checkpoint.stats.credits_used += credits
+
+        for work_id in failed_work_ids:
+            checkpoint.failed_work_ids.add(work_id)
+            checkpoint.stats.total_failed += 1
+
+        checkpoint.current_cursor = cursor or "*"
+        checkpoint.pages_completed += 1
+        checkpoint.stats.last_updated_at = time.time()
+        self._save()
+        self._pending_saves = 0
+
     def _maybe_save(self) -> None:
         """Save checkpoint if threshold reached."""
         self._pending_saves += 1
@@ -182,8 +215,7 @@ class CheckpointManager:
         """Save checkpoint to disk."""
         checkpoint = self.get()
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.checkpoint_path, "w") as f:
-            json.dump(checkpoint.to_dict(), f, indent=2)
+        atomic_write_json(self.checkpoint_path, checkpoint.to_dict())
 
     def force_save(self) -> None:
         """Force an immediate save (e.g., on shutdown)."""

--- a/src/openalex_cli/cli.py
+++ b/src/openalex_cli/cli.py
@@ -81,8 +81,7 @@ async def _resolve_identifiers(
                     original_map[work_id] = doi  # Remember original DOI for filename
                 elif not quiet:
                     click.echo(
-                        click.style("Warning: ", fg="yellow")
-                        + f"DOI not found in OpenAlex: {doi}"
+                        click.style("Warning: ", fg="yellow") + f"DOI not found in OpenAlex: {doi}"
                     )
         finally:
             await client.close()
@@ -260,20 +259,15 @@ def download(
         raw_ids = _parse_input_ids(ids_str, use_stdin)
         if not raw_ids:
             click.echo(
-                click.style("Error: ", fg="red")
-                + "No work IDs provided. Check your input.",
+                click.style("Error: ", fg="red") + "No work IDs provided. Check your input.",
                 err=True,
             )
             if use_stdin:
                 click.echo("  stdin was empty — verify your pipe or input file.", err=True)
             sys.exit(1)
-        work_ids, original_identifiers = asyncio.run(
-            _resolve_identifiers(raw_ids, api_key, quiet)
-        )
+        work_ids, original_identifiers = asyncio.run(_resolve_identifiers(raw_ids, api_key, quiet))
         if not work_ids:
-            click.echo(
-                click.style("Error: ", fg="red") + "No valid work IDs found.", err=True
-            )
+            click.echo(click.style("Error: ", fg="red") + "No valid work IDs found.", err=True)
             sys.exit(1)
         if not quiet:
             click.echo(f"Found {len(work_ids)} work(s) to download.")
@@ -282,9 +276,7 @@ def download(
     content_format = ContentFormat.NONE
     if content_types:
         types = [t.strip().lower() for t in content_types.split(",")]
-        if "pdf" in types and "xml" in types:
-            content_format = ContentFormat.BOTH
-        elif "both" in types:
+        if ("pdf" in types and "xml" in types) or "both" in types:
             content_format = ContentFormat.BOTH
         elif "pdf" in types:
             content_format = ContentFormat.PDF
@@ -372,7 +364,7 @@ def status(api_key: str) -> None:
         client = OpenAlexAPIClient(api_key=api_key)
         try:
             status = await client.get_status()
-            click.echo(f"API Key Status:")
+            click.echo("API Key Status:")
             click.echo(f"  Rate limit remaining: {status.rate_limit_remaining:,}")
             click.echo()
             click.echo("Note: Full credit information requires a premium API key.")

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -6,11 +6,13 @@ import asyncio
 import json
 import signal
 import time
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Callable
 
 from .api_client import CreditsExhaustedError, DownloadResult, OpenAlexAPIClient, WorkItem
 from .checkpoint import CheckpointManager
+from .fault_injection import FailureInjector
 from .page_tracker import PageTracker
 from .progress import ProgressTracker
 from .rate_limiter import AdaptiveRateLimiter
@@ -65,6 +67,7 @@ class DownloadOrchestrator:
         self.rate_limiter = AdaptiveRateLimiter(max_workers=config.workers)
         self.checkpoint_manager = CheckpointManager(config.output_path)
         self.page_tracker = PageTracker(config.output_path, self.checkpoint_manager)
+        self.failure_injector = FailureInjector()
         self.progress_tracker: ProgressTracker | None = None
 
         # Initialize storage backend
@@ -269,14 +272,18 @@ class DownloadOrchestrator:
                         page_seq=replay.page_seq,
                     )
                 )
+                self.failure_injector.hit("after_replay_enqueue")
             cursor = self.page_tracker.resume_cursor(cursor) or cursor
 
+        page_iter = self.api_client.list_works(
+            filter_str=self.config.filter_str,
+            content_format=self.config.content_format,
+            cursor=cursor,
+        )
+        closable_page_iter = page_iter if isinstance(page_iter, AsyncGenerator) else None
+
         try:
-            async for works, next_cursor in self.api_client.list_works(
-                filter_str=self.config.filter_str,
-                content_format=self.config.content_format,
-                cursor=cursor,
-            ):
+            async for works, next_cursor in page_iter:
                 if self._shutdown_requested:
                     break
 
@@ -305,6 +312,7 @@ class DownloadOrchestrator:
                         cursor_out=next_cursor,
                         work_ids=work_ids,
                     ).seq
+                    self.failure_injector.hit("after_page_register")
 
                 for work in queueable_works:
                     if self._shutdown_requested:
@@ -329,6 +337,10 @@ class DownloadOrchestrator:
         except Exception as e:
             if self.progress_tracker:
                 self.progress_tracker.log_error(f"Error listing works: {e}")
+            raise
+        finally:
+            if closable_page_iter is not None:
+                await closable_page_iter.aclose()
 
     async def _produce_work_from_sample(self) -> None:
         """Queue work items from a random sample (page-based pagination)."""
@@ -568,11 +580,13 @@ class DownloadOrchestrator:
                     credits=result.credits_cost,
                     error=result.error,
                 )
+                self.failure_injector.hit("after_result_record")
                 if self.progress_tracker and commit.committed_pages:
                     self.progress_tracker.update_pagination(
                         pages=commit.pages_completed,
                         cursor=commit.current_cursor,
                     )
+                    self.failure_injector.hit("after_page_commit")
             else:
                 if result.success:
                     self.checkpoint_manager.mark_completed(

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -7,11 +7,11 @@ import json
 import signal
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Callable
 
 from .api_client import CreditsExhaustedError, DownloadResult, OpenAlexAPIClient, WorkItem
 from .checkpoint import CheckpointManager
+from .page_tracker import PageTracker
 from .progress import ProgressTracker
 from .rate_limiter import AdaptiveRateLimiter
 from .storage import LocalStorage, S3Storage, StorageBackend
@@ -41,6 +41,14 @@ class DownloadConfig:
     seed: int | None = None  # Seed for reproducible random samples
 
 
+@dataclass
+class QueuedWork:
+    """Work queued for download with optional page-tracking context."""
+
+    work: WorkItem
+    page_seq: int | None = None
+
+
 class DownloadOrchestrator:
     """Orchestrates the bulk download process."""
 
@@ -56,12 +64,17 @@ class DownloadOrchestrator:
         self.api_client = OpenAlexAPIClient(api_key=config.api_key)
         self.rate_limiter = AdaptiveRateLimiter(max_workers=config.workers)
         self.checkpoint_manager = CheckpointManager(config.output_path)
+        self.page_tracker = PageTracker(config.output_path, self.checkpoint_manager)
         self.progress_tracker: ProgressTracker | None = None
 
         # Initialize storage backend
         if config.storage_type == StorageType.S3:
             if not config.s3_bucket:
                 raise ValueError("S3 bucket required for S3 storage")
+            if S3Storage is None:
+                raise RuntimeError(
+                    "S3 storage requires the optional aiobotocore dependency to be installed"
+                )
             self.storage: StorageBackend = S3Storage(
                 bucket=config.s3_bucket,
                 prefix=config.s3_prefix,
@@ -72,8 +85,13 @@ class DownloadOrchestrator:
         # Control flags
         self._shutdown_requested = False
         self._credits_exhausted = False
+        self._page_tracking_enabled = (
+            self.config.content_format == ContentFormat.NONE
+            and not self.config.sample
+            and not self.config.work_ids
+        )
         # Queues are created in run() to ensure they're in the correct event loop
-        self._work_queue: asyncio.Queue[WorkItem | None] | None = None
+        self._work_queue: asyncio.Queue[QueuedWork | None] | None = None
         self._results_queue: asyncio.Queue[DownloadResult] | None = None
 
     async def run(self, progress_tracker: ProgressTracker | None = None) -> None:
@@ -86,14 +104,28 @@ class DownloadOrchestrator:
 
         # Set up signal handlers for graceful shutdown
         loop = asyncio.get_running_loop()
+        signal_handlers_installed = False
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, self._request_shutdown)
+            try:
+                loop.add_signal_handler(sig, self._request_shutdown)
+                signal_handlers_installed = True
+            except NotImplementedError:
+                signal_handlers_installed = False
+                break
 
         try:
             # Initialize or resume checkpoint
             checkpoint = self._setup_checkpoint()
             if checkpoint is None:
                 return
+
+            if self._page_tracking_enabled:
+                commit = self.page_tracker.startup_reconcile()
+                if self.progress_tracker and commit.committed_pages:
+                    self.progress_tracker.update_pagination(
+                        pages=commit.pages_completed,
+                        cursor=commit.current_cursor,
+                    )
 
             # Log start
             if self.progress_tracker:
@@ -111,8 +143,7 @@ class DownloadOrchestrator:
 
             # Start worker tasks
             workers = [
-                asyncio.create_task(self._download_worker(i))
-                for i in range(self.config.workers)
+                asyncio.create_task(self._download_worker(i)) for i in range(self.config.workers)
             ]
 
             # Start result processor
@@ -144,8 +175,9 @@ class DownloadOrchestrator:
             await self.storage.close()
 
             # Remove signal handlers
-            for sig in (signal.SIGINT, signal.SIGTERM):
-                loop.remove_signal_handler(sig)
+            if signal_handlers_installed:
+                for sig in (signal.SIGINT, signal.SIGTERM):
+                    loop.remove_signal_handler(sig)
 
     def _request_shutdown(self) -> None:
         """Handle shutdown signal."""
@@ -154,9 +186,7 @@ class DownloadOrchestrator:
             raise KeyboardInterrupt()
         self._shutdown_requested = True
         if self.progress_tracker:
-            self.progress_tracker.log_warning(
-                "Shutdown requested. Finishing current downloads..."
-            )
+            self.progress_tracker.log_warning("Shutdown requested. Finishing current downloads...")
 
     def _handle_credits_exhausted(self) -> None:
         """Stop all work when credits are exhausted."""
@@ -230,6 +260,17 @@ class DownloadOrchestrator:
         warned_about_flat = False
         total_count = 0
 
+        if self._page_tracking_enabled:
+            assert self._work_queue is not None
+            for replay in self.page_tracker.replay_pending_work():
+                await self._work_queue.put(
+                    QueuedWork(
+                        work=WorkItem(work_id=replay.work_id),
+                        page_seq=replay.page_seq,
+                    )
+                )
+            cursor = self.page_tracker.resume_cursor(cursor) or cursor
+
         try:
             async for works, next_cursor in self.api_client.list_works(
                 filter_str=self.config.filter_str,
@@ -253,24 +294,35 @@ class DownloadOrchestrator:
                     )
                     warned_about_flat = True
 
-                for work in works:
+                page_seq: int | None = None
+                queueable_works = [
+                    work for work in works if not self.checkpoint_manager.is_completed(work.work_id)
+                ]
+                work_ids = [work.work_id for work in queueable_works]
+                if self._page_tracking_enabled and work_ids:
+                    page_seq = self.page_tracker.register_page(
+                        cursor_in=cursor,
+                        cursor_out=next_cursor,
+                        work_ids=work_ids,
+                    ).seq
+
+                for work in queueable_works:
                     if self._shutdown_requested:
                         break
 
-                    # Skip already completed
-                    if self.checkpoint_manager.is_completed(work.work_id):
-                        continue
+                    assert self._work_queue is not None
+                    await self._work_queue.put(QueuedWork(work=work, page_seq=page_seq))
 
-                    await self._work_queue.put(work)
+                if not self._page_tracking_enabled:
+                    self.checkpoint_manager.update_cursor(next_cursor)
 
-                # Update cursor checkpoint
-                self.checkpoint_manager.update_cursor(next_cursor)
-
-                if self.progress_tracker:
+                if self.progress_tracker and not self._page_tracking_enabled:
                     self.progress_tracker.update_pagination(
                         pages=checkpoint.pages_completed,
                         cursor=next_cursor,
                     )
+
+                cursor = next_cursor or "*"
 
         except CreditsExhaustedError:
             self._handle_credits_exhausted()
@@ -282,10 +334,14 @@ class DownloadOrchestrator:
         """Queue work items from a random sample (page-based pagination)."""
         total_count = 0
         warned_about_flat = False
+        sample_size = self.config.sample
+
+        if sample_size is None:
+            return
 
         try:
             async for works in self.api_client.list_works_sample(
-                sample_size=self.config.sample,
+                sample_size=sample_size,
                 seed=self.config.seed,
                 filter_str=self.config.filter_str,
                 content_format=self.config.content_format,
@@ -314,12 +370,11 @@ class DownloadOrchestrator:
                     if self.checkpoint_manager.is_completed(work.work_id):
                         continue
 
-                    await self._work_queue.put(work)
+                    assert self._work_queue is not None
+                    await self._work_queue.put(QueuedWork(work=work))
 
                 if self.progress_tracker:
-                    self.progress_tracker.log_info(
-                        f"Queued {total_count} works from sample..."
-                    )
+                    self.progress_tracker.log_info(f"Queued {total_count} works from sample...")
 
         except CreditsExhaustedError:
             self._handle_credits_exhausted()
@@ -346,7 +401,8 @@ class DownloadOrchestrator:
                 # Fetch work metadata from singleton API
                 metadata = await self.api_client.get_work_metadata(work_id)
                 work = WorkItem.from_api_response(metadata)
-                await self._work_queue.put(work)
+                assert self._work_queue is not None
+                await self._work_queue.put(QueuedWork(work=work))
             except Exception as e:
                 if self.progress_tracker:
                     self.progress_tracker.log_error(f"Error fetching metadata for {work_id}: {e}")
@@ -355,12 +411,15 @@ class DownloadOrchestrator:
         """Worker that downloads metadata and optionally content."""
         while not self._shutdown_requested:
             try:
-                work = await asyncio.wait_for(self._work_queue.get(), timeout=1.0)
+                assert self._work_queue is not None
+                queued = await asyncio.wait_for(self._work_queue.get(), timeout=1.0)
             except asyncio.TimeoutError:
                 continue
 
-            if work is None:
+            if queued is None:
                 break
+
+            work = queued.work
 
             # Determine filename base: use original DOI if provided, else work_id
             filename_base = work.work_id
@@ -376,9 +435,7 @@ class DownloadOrchestrator:
             # Always save full metadata (fetch from singleton API)
             try:
                 full_metadata = await self.api_client.get_work_metadata(work.work_id)
-                meta_path = str(
-                    work_id_to_path(filename_base, "json", nested=self.config.nested)
-                )
+                meta_path = str(work_id_to_path(filename_base, "json", nested=self.config.nested))
                 meta_content = json.dumps(full_metadata, indent=2).encode()
                 await self.storage.save(meta_path, meta_content, "application/json")
             except CreditsExhaustedError:
@@ -390,6 +447,19 @@ class DownloadOrchestrator:
                         f"Failed to fetch metadata for {work.work_id}: {e}"
                     )
 
+                if self.config.content_format == ContentFormat.NONE:
+                    assert self._results_queue is not None
+                    await self._results_queue.put(
+                        DownloadResult(
+                            work_id=work.work_id,
+                            format=ContentFormat.NONE,
+                            success=False,
+                            error=str(e),
+                            page_seq=queued.page_seq,
+                        )
+                    )
+                continue
+
             # If no content requested, we're done with this work
             if self.config.content_format == ContentFormat.NONE:
                 # Report success for metadata-only download
@@ -397,20 +467,26 @@ class DownloadOrchestrator:
                     work_id=work.work_id,
                     format=ContentFormat.NONE,
                     success=True,
-                    file_size=len(meta_content) if meta_content else 0,
+                    file_size=len(meta_content),
                     credits_cost=0,  # Singleton API is free
+                    page_seq=queued.page_seq,
                 )
+                assert self._results_queue is not None
                 await self._results_queue.put(result)
                 continue
 
             # Determine content formats to download
             formats = []
-            if self.config.content_format in (ContentFormat.PDF, ContentFormat.BOTH):
-                if work.has_pdf:
-                    formats.append(ContentFormat.PDF)
-            if self.config.content_format in (ContentFormat.XML, ContentFormat.BOTH):
-                if work.has_xml:
-                    formats.append(ContentFormat.XML)
+            if (
+                self.config.content_format in (ContentFormat.PDF, ContentFormat.BOTH)
+                and work.has_pdf
+            ):
+                formats.append(ContentFormat.PDF)
+            if (
+                self.config.content_format in (ContentFormat.XML, ContentFormat.BOTH)
+                and work.has_xml
+            ):
+                formats.append(ContentFormat.XML)
 
             # If no content available for requested formats, report success (metadata was saved)
             if not formats:
@@ -418,9 +494,11 @@ class DownloadOrchestrator:
                     work_id=work.work_id,
                     format=self.config.content_format,
                     success=True,
-                    file_size=len(meta_content) if meta_content else 0,
+                    file_size=len(meta_content),
                     credits_cost=0,
+                    page_seq=queued.page_seq,
                 )
+                assert self._results_queue is not None
                 await self._results_queue.put(result)
                 continue
 
@@ -454,6 +532,8 @@ class DownloadOrchestrator:
                         )
                         await self.storage.save(path, result.content, content_type)
 
+                    result.page_seq = queued.page_seq
+                    assert self._results_queue is not None
                     await self._results_queue.put(result)
 
                 except Exception as e:
@@ -462,7 +542,9 @@ class DownloadOrchestrator:
                         format=fmt,
                         success=False,
                         error=str(e),
+                        page_seq=queued.page_seq,
                     )
+                    assert self._results_queue is not None
                     await self._results_queue.put(result)
 
                 finally:
@@ -471,19 +553,35 @@ class DownloadOrchestrator:
     async def _process_results(self) -> None:
         """Process download results and update progress."""
         while True:
+            assert self._results_queue is not None
             result = await self._results_queue.get()
 
             if result.work_id == "__DONE__":
                 break
 
-            if result.success:
-                self.checkpoint_manager.mark_completed(
-                    result.work_id,
-                    result.file_size,
-                    result.credits_cost,
+            if self._page_tracking_enabled and result.page_seq is not None:
+                commit = self.page_tracker.record_work_result(
+                    page_seq=result.page_seq,
+                    work_id=result.work_id,
+                    success=result.success,
+                    file_size=result.file_size,
+                    credits=result.credits_cost,
+                    error=result.error,
                 )
+                if self.progress_tracker and commit.committed_pages:
+                    self.progress_tracker.update_pagination(
+                        pages=commit.pages_completed,
+                        cursor=commit.current_cursor,
+                    )
             else:
-                self.checkpoint_manager.mark_failed(result.work_id)
+                if result.success:
+                    self.checkpoint_manager.mark_completed(
+                        result.work_id,
+                        result.file_size,
+                        result.credits_cost,
+                    )
+                else:
+                    self.checkpoint_manager.mark_failed(result.work_id)
 
             if self.progress_tracker:
                 self.progress_tracker.update_download(

--- a/src/openalex_cli/fault_injection.py
+++ b/src/openalex_cli/fault_injection.py
@@ -1,0 +1,58 @@
+"""Controlled failure hooks for smoke-testing downloader recovery."""
+
+from __future__ import annotations
+
+import os
+
+
+class InjectedFailure(RuntimeError):
+    """Raised when a configured failure hook is triggered."""
+
+
+class FailureInjector:
+    """One-shot failure injection controlled by environment variables."""
+
+    POINTS_ENV = "OPENALEX_FAILPOINTS"
+    COUNTS_ENV = "OPENALEX_FAILCOUNTS"
+
+    def __init__(self) -> None:
+        self._points = self._parse_points(os.getenv(self.POINTS_ENV, ""))
+        self._counts = self._parse_counts(os.getenv(self.COUNTS_ENV, ""))
+        self._hits: dict[str, int] = {}
+
+    def hit(self, point: str) -> None:
+        """Trigger a configured failure once the failpoint threshold is reached."""
+        if point not in self._points:
+            return
+
+        hit_count = self._hits.get(point, 0) + 1
+        self._hits[point] = hit_count
+        target = self._counts.get(point, 1)
+        if hit_count >= target:
+            raise InjectedFailure(f"Injected failure at failpoint '{point}'")
+
+    @staticmethod
+    def _parse_points(raw: str) -> set[str]:
+        return {point.strip() for point in raw.split(",") if point.strip()}
+
+    @staticmethod
+    def _parse_counts(raw: str) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for entry in raw.split(","):
+            item = entry.strip()
+            if not item or ":" not in item:
+                continue
+
+            name, value = item.split(":", 1)
+            point = name.strip()
+            if not point:
+                continue
+
+            try:
+                count = int(value)
+            except ValueError:
+                continue
+
+            if count > 0:
+                counts[point] = count
+        return counts

--- a/src/openalex_cli/page_tracker.py
+++ b/src/openalex_cli/page_tracker.py
@@ -1,0 +1,264 @@
+"""Persisted page tracking for safe metadata-only resume."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .checkpoint import CheckpointManager
+from .state_io import atomic_write_json
+
+
+@dataclass
+class PageWorkState:
+    """Terminal state for a work admitted from a page."""
+
+    state: str = "pending"
+    file_size: int = 0
+    credits: int = 0
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "file_size": self.file_size,
+            "credits": self.credits,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PageWorkState:
+        return cls(
+            state=data.get("state", "pending"),
+            file_size=data.get("file_size", 0),
+            credits=data.get("credits", 0),
+            error=data.get("error"),
+        )
+
+
+@dataclass
+class PageManifest:
+    """Durable record of a listed page and each admitted work."""
+
+    seq: int
+    cursor_in: str
+    cursor_out: str | None
+    work_ids: list[str]
+    work_states: dict[str, PageWorkState] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for work_id in self.work_ids:
+            self.work_states.setdefault(work_id, PageWorkState())
+
+    def to_dict(self) -> dict:
+        return {
+            "seq": self.seq,
+            "cursor_in": self.cursor_in,
+            "cursor_out": self.cursor_out,
+            "work_ids": self.work_ids,
+            "work_states": {
+                work_id: state.to_dict() for work_id, state in self.work_states.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PageManifest:
+        return cls(
+            seq=data["seq"],
+            cursor_in=data.get("cursor_in", "*"),
+            cursor_out=data.get("cursor_out"),
+            work_ids=list(data.get("work_ids", [])),
+            work_states={
+                work_id: PageWorkState.from_dict(state)
+                for work_id, state in data.get("work_states", {}).items()
+            },
+        )
+
+    def is_terminal(self) -> bool:
+        return all(self.work_states[work_id].state != "pending" for work_id in self.work_ids)
+
+    def pending_work_ids(self) -> list[str]:
+        return [
+            work_id for work_id in self.work_ids if self.work_states[work_id].state == "pending"
+        ]
+
+    def completed_entries(self) -> list[tuple[str, int, int]]:
+        entries: list[tuple[str, int, int]] = []
+        for work_id in self.work_ids:
+            state = self.work_states[work_id]
+            if state.state == "completed":
+                entries.append((work_id, state.file_size, state.credits))
+        return entries
+
+    def failed_work_ids(self) -> list[str]:
+        return [work_id for work_id in self.work_ids if self.work_states[work_id].state == "failed"]
+
+
+@dataclass
+class ReplayWorkItem:
+    """Pending work reconstructed from a durable page manifest."""
+
+    page_seq: int
+    work_id: str
+
+
+@dataclass
+class CommitOutcome:
+    """Result of recording a terminal work outcome."""
+
+    committed_pages: int = 0
+    current_cursor: str | None = None
+    pages_completed: int = 0
+
+
+class PageStateStore:
+    """Durable local storage for admitted page manifests."""
+
+    DIRNAME = ".openalex-pages"
+
+    def __init__(self, output_dir: str | Path):
+        self.base_dir = Path(output_dir) / self.DIRNAME
+
+    def list_manifests(self) -> list[PageManifest]:
+        if not self.base_dir.exists():
+            return []
+
+        manifests: list[PageManifest] = []
+        for path in sorted(self.base_dir.glob("page-*.json")):
+            with open(path, encoding="utf-8") as f:
+                manifests.append(PageManifest.from_dict(json.load(f)))
+        manifests.sort(key=lambda manifest: manifest.seq)
+        return manifests
+
+    def has_manifests(self) -> bool:
+        """Return True when any persisted page manifests exist."""
+        return any(self.base_dir.glob("page-*.json")) if self.base_dir.exists() else False
+
+    def save_manifest(self, manifest: PageManifest) -> None:
+        atomic_write_json(self._manifest_path(manifest.seq), manifest.to_dict())
+
+    def delete_manifest(self, seq: int) -> None:
+        path = self._manifest_path(seq)
+        if path.exists():
+            path.unlink()
+
+    def next_seq(self) -> int:
+        manifests = self.list_manifests()
+        return (manifests[-1].seq + 1) if manifests else 1
+
+    def _manifest_path(self, seq: int) -> Path:
+        return self.base_dir / f"page-{seq:08d}.json"
+
+
+class PageTracker:
+    """Own durable state for uncommitted metadata-only pages."""
+
+    def __init__(self, output_dir: str | Path, checkpoint_manager: CheckpointManager):
+        self.checkpoint_manager = checkpoint_manager
+        self.state_store = PageStateStore(output_dir)
+
+    def startup_reconcile(self) -> CommitOutcome:
+        for manifest in self.state_store.list_manifests():
+            if self._manifest_is_already_committed(manifest):
+                self.state_store.delete_manifest(manifest.seq)
+
+        return self._commit_ready_pages()
+
+    def has_uncommitted_pages(self) -> bool:
+        """Return True when durable uncommitted page manifests remain."""
+        return self.state_store.has_manifests()
+
+    def resume_cursor(self, default_cursor: str) -> str | None:
+        """Return the cursor to use for fresh pagination after replay."""
+        manifests = self.state_store.list_manifests()
+        if not manifests:
+            return default_cursor
+        return manifests[-1].cursor_out
+
+    def register_page(
+        self,
+        cursor_in: str,
+        cursor_out: str | None,
+        work_ids: list[str],
+    ) -> PageManifest:
+        manifest = PageManifest(
+            seq=self.state_store.next_seq(),
+            cursor_in=cursor_in,
+            cursor_out=cursor_out,
+            work_ids=work_ids,
+        )
+        self.state_store.save_manifest(manifest)
+        return manifest
+
+    def replay_pending_work(self) -> list[ReplayWorkItem]:
+        replay: list[ReplayWorkItem] = []
+        for manifest in self.state_store.list_manifests():
+            for work_id in manifest.pending_work_ids():
+                replay.append(ReplayWorkItem(page_seq=manifest.seq, work_id=work_id))
+        return replay
+
+    def record_work_result(
+        self,
+        page_seq: int,
+        work_id: str,
+        success: bool,
+        file_size: int,
+        credits: int,
+        error: str | None,
+    ) -> CommitOutcome:
+        manifest = self._load_manifest(page_seq)
+        if manifest is None:
+            return CommitOutcome()
+
+        state = manifest.work_states.get(work_id)
+        if state is None or state.state != "pending":
+            return CommitOutcome()
+
+        manifest.work_states[work_id] = PageWorkState(
+            state="completed" if success else "failed",
+            file_size=file_size,
+            credits=credits,
+            error=error,
+        )
+        self.state_store.save_manifest(manifest)
+        return self._commit_ready_pages()
+
+    def _commit_ready_pages(self) -> CommitOutcome:
+        committed_pages = 0
+        checkpoint = self.checkpoint_manager.get()
+
+        for manifest in self.state_store.list_manifests():
+            if self._manifest_is_already_committed(manifest):
+                self.state_store.delete_manifest(manifest.seq)
+                continue
+
+            if not manifest.is_terminal():
+                break
+
+            self.checkpoint_manager.commit_page(
+                cursor=manifest.cursor_out,
+                completed_entries=manifest.completed_entries(),
+                failed_work_ids=manifest.failed_work_ids(),
+            )
+            self.state_store.delete_manifest(manifest.seq)
+            committed_pages += 1
+            checkpoint = self.checkpoint_manager.get()
+
+        return CommitOutcome(
+            committed_pages=committed_pages,
+            current_cursor=checkpoint.current_cursor,
+            pages_completed=checkpoint.pages_completed,
+        )
+
+    def _manifest_is_already_committed(self, manifest: PageManifest) -> bool:
+        terminal_ids = self.checkpoint_manager.terminal_work_ids()
+        return bool(manifest.work_ids) and all(
+            work_id in terminal_ids for work_id in manifest.work_ids
+        )
+
+    def _load_manifest(self, seq: int) -> PageManifest | None:
+        for manifest in self.state_store.list_manifests():
+            if manifest.seq == seq:
+                return manifest
+        return None

--- a/src/openalex_cli/rate_limiter.py
+++ b/src/openalex_cli/rate_limiter.py
@@ -190,7 +190,7 @@ class AdaptiveRateLimiter:
         Returns the actual wait time in seconds.
         """
         wait_time = min(
-            self._current_backoff * (self.BACKOFF_MULTIPLIER ** self._consecutive_errors),
+            self._current_backoff * (self.BACKOFF_MULTIPLIER**self._consecutive_errors),
             self.MAX_BACKOFF,
         )
         await asyncio.sleep(wait_time)
@@ -219,6 +219,4 @@ class AdaptiveRateLimiter:
     def should_continue(self) -> bool:
         """Check if we should continue making requests."""
         # Stop if rate limit is exhausted
-        if self._rate_limit_remaining is not None and self._rate_limit_remaining <= 0:
-            return False
-        return True
+        return not (self._rate_limit_remaining is not None and self._rate_limit_remaining <= 0)

--- a/src/openalex_cli/state_io.py
+++ b/src/openalex_cli/state_io.py
@@ -1,0 +1,38 @@
+"""Helpers for durable local state writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Atomically replace a file with the provided bytes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+
+        os.replace(tmp_path, path)
+    except Exception:
+        with suppress(FileNotFoundError):
+            os.unlink(tmp_path)
+        raise
+
+
+def atomic_write_json(path: Path, data: Any) -> None:
+    """Atomically replace a JSON file."""
+    atomic_write_bytes(path, json.dumps(data, indent=2).encode("utf-8"))

--- a/src/openalex_cli/storage/__init__.py
+++ b/src/openalex_cli/storage/__init__.py
@@ -1,7 +1,13 @@
 """Storage backends for the OpenAlex content downloader."""
 
+from importlib import import_module
+
 from .base import StorageBackend
 from .local import LocalStorage
-from .s3 import S3Storage
+
+try:
+    S3Storage = import_module("openalex_cli.storage.s3").S3Storage
+except ModuleNotFoundError:  # pragma: no cover - optional dependency in local-only environments
+    S3Storage = None
 
 __all__ = ["StorageBackend", "LocalStorage", "S3Storage"]

--- a/src/openalex_cli/storage/local.py
+++ b/src/openalex_cli/storage/local.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+from ..state_io import atomic_write_bytes
 from .base import StorageBackend
 
 
@@ -37,7 +38,7 @@ class LocalStorage(StorageBackend):
 
     def _write_file(self, path: Path, content: bytes) -> None:
         """Synchronous file write."""
-        path.write_bytes(content)
+        atomic_write_bytes(path, content)
 
     async def exists(self, path: str) -> bool:
         """Check if a file exists."""

--- a/src/openalex_cli/storage/s3.py
+++ b/src/openalex_cli/storage/s3.py
@@ -3,14 +3,10 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
 
-from aiobotocore.session import get_session
+from aiobotocore.session import get_session  # type: ignore[import-untyped]
 
 from .base import StorageBackend
-
-if TYPE_CHECKING:
-    from types_aiobotocore_s3 import S3Client
 
 
 class S3Storage(StorageBackend):

--- a/src/openalex_cli/utils.py
+++ b/src/openalex_cli/utils.py
@@ -125,13 +125,14 @@ def doi_to_filename(doi: str) -> str:
     return doi.replace("/", "_").replace(":", "_")
 
 
-def format_bytes(num_bytes: int) -> str:
+def format_bytes(num_bytes: float) -> str:
     """Format bytes as human-readable string."""
+    value = float(num_bytes)
     for unit in ["B", "KB", "MB", "GB", "TB"]:
-        if abs(num_bytes) < 1024:
-            return f"{num_bytes:.1f} {unit}"
-        num_bytes /= 1024
-    return f"{num_bytes:.1f} PB"
+        if abs(value) < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} PB"
 
 
 def format_rate(bytes_per_second: float) -> str:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,12 +1,8 @@
 """Tests for checkpoint system."""
 
-import json
 import tempfile
-from pathlib import Path
 
-import pytest
-
-from openalex_cli.checkpoint import Checkpoint, CheckpointManager, DownloadStats
+from openalex_cli.checkpoint import Checkpoint, CheckpointManager
 
 
 class TestCheckpoint:
@@ -111,3 +107,23 @@ class TestCheckpointManager:
             manager2 = CheckpointManager(tmpdir)
             loaded = manager2.load()
             assert len(loaded.completed_work_ids) == 100
+
+    def test_commit_page(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = CheckpointManager(tmpdir)
+            manager.create(filter_str="type:article", content_format="none")
+
+            manager.commit_page(
+                cursor="cursor_abc",
+                completed_entries=[("W1", 100, 0), ("W2", 200, 0)],
+                failed_work_ids=["W3"],
+            )
+
+            checkpoint = manager.get()
+            assert checkpoint.current_cursor == "cursor_abc"
+            assert checkpoint.pages_completed == 1
+            assert checkpoint.completed_work_ids == {"W1", "W2"}
+            assert checkpoint.failed_work_ids == {"W3"}
+            assert checkpoint.stats.total_downloaded == 2
+            assert checkpoint.stats.total_failed == 1
+            assert checkpoint.stats.total_bytes == 300

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 
-from openalex_cli.api_client import WorkItem
+from openalex_cli.api_client import DownloadResult, WorkItem
 from openalex_cli.downloader import DownloadConfig, DownloadOrchestrator, QueuedWork
 from openalex_cli.progress import ProgressTracker
 from openalex_cli.utils import ContentFormat, StorageType
@@ -172,3 +172,236 @@ async def test_run_commits_terminal_manifest_during_startup_reconcile(tmp_path):
 
 async def _async_noop():
     return None
+
+
+async def _drain_metadata_only_run(orchestrator: DownloadOrchestrator) -> None:
+    """Run producer, one worker, and result processor to convergence."""
+    orchestrator._work_queue = asyncio.Queue()
+    orchestrator._results_queue = asyncio.Queue()
+
+    worker = asyncio.create_task(orchestrator._download_worker(0))
+    result_processor = asyncio.create_task(orchestrator._process_results())
+
+    await orchestrator._produce_work()
+    await orchestrator._work_queue.put(None)
+    await worker
+    await orchestrator._results_queue.put(
+        DownloadResult(work_id="__DONE__", format=ContentFormat.NONE, success=True)
+    )
+    await result_processor
+
+
+def _metadata_doc(work_id: str) -> dict[str, Any]:
+    return {
+        "id": f"https://openalex.org/{work_id}",
+        "has_content": {},
+        "title": work_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_failpoint_triggers_after_page_register(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_page_register")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator._work_queue = asyncio.Queue()
+
+    async def one_page(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format, cursor
+        yield [WorkItem(work_id="W1")], "cursor-1"
+
+    orchestrator.api_client.list_works = one_page  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="after_page_register"):
+        await orchestrator._produce_work()
+
+    manifests = orchestrator.page_tracker.state_store.list_manifests()
+    assert len(manifests) == 1
+    assert manifests[0].work_ids == ["W1"]
+
+
+@pytest.mark.asyncio
+async def test_failpoint_triggers_after_page_commit(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_page_commit")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    page = orchestrator.page_tracker.register_page("*", "cursor-1", ["W1"])
+    orchestrator._results_queue = asyncio.Queue()
+    await orchestrator._results_queue.put(
+        DownloadResult(
+            work_id="W1",
+            format=ContentFormat.NONE,
+            success=True,
+            file_size=10,
+            credits_cost=0,
+            page_seq=page.seq,
+        )
+    )
+    await orchestrator._results_queue.put(
+        DownloadResult(work_id="__DONE__", format=ContentFormat.NONE, success=True)
+    )
+
+    with pytest.raises(RuntimeError, match="after_page_commit"):
+        await orchestrator._process_results()
+
+    checkpoint = orchestrator.checkpoint_manager.get()
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.completed_work_ids == {"W1"}
+    assert orchestrator.page_tracker.state_store.list_manifests() == []
+
+
+@pytest.mark.asyncio
+async def test_restart_after_page_register_replays_from_disk_and_converges(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_page_register")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+
+    first = DownloadOrchestrator(config)
+    first.checkpoint_manager.create(filter_str=None, content_format="none")
+    first._work_queue = asyncio.Queue()
+
+    async def one_page_then_stop(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        if cursor == "*":
+            yield [WorkItem(work_id="W1")], "cursor-1"
+
+    first.api_client.list_works = one_page_then_stop  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="after_page_register"):
+        await first._produce_work()
+
+    assert first.page_tracker.state_store.list_manifests()[0].work_ids == ["W1"]
+
+    monkeypatch.delenv("OPENALEX_FAILPOINTS")
+
+    second = DownloadOrchestrator(config)
+    second._setup_checkpoint()
+    fetches: list[str] = []
+    second.api_client.close = _async_noop  # type: ignore[method-assign]
+    second.storage.close = _async_noop  # type: ignore[method-assign]
+
+    async def no_new_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        assert cursor == "cursor-1"
+        if False:
+            yield [], None
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        fetches.append(work_id)
+        return _metadata_doc(work_id)
+
+    second.api_client.list_works = no_new_pages  # type: ignore[method-assign]
+    second.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+
+    await _drain_metadata_only_run(second)
+
+    checkpoint = second.checkpoint_manager.get()
+    assert fetches == ["W1"]
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.completed_work_ids == {"W1"}
+    assert second.page_tracker.state_store.list_manifests() == []
+    assert (tmp_path / "W1.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_restart_after_result_record_replays_only_remaining_work(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_result_record")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+
+    first = DownloadOrchestrator(config)
+    first.checkpoint_manager.create(filter_str=None, content_format="none")
+    page = first.page_tracker.register_page("*", "cursor-1", ["W1", "W2"])
+    first._results_queue = asyncio.Queue()
+    await first._results_queue.put(
+        DownloadResult(
+            work_id="W1",
+            format=ContentFormat.NONE,
+            success=True,
+            file_size=10,
+            credits_cost=0,
+            page_seq=page.seq,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="after_result_record"):
+        await first._process_results()
+
+    manifest = first.page_tracker.state_store.list_manifests()[0]
+    assert manifest.work_states["W1"].state == "completed"
+    assert manifest.work_states["W2"].state == "pending"
+
+    monkeypatch.delenv("OPENALEX_FAILPOINTS")
+
+    second = DownloadOrchestrator(config)
+    second._setup_checkpoint()
+    fetches: list[str] = []
+    second.api_client.close = _async_noop  # type: ignore[method-assign]
+    second.storage.close = _async_noop  # type: ignore[method-assign]
+
+    async def no_new_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        assert cursor == "cursor-1"
+        if False:
+            yield [], None
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        fetches.append(work_id)
+        return _metadata_doc(work_id)
+
+    second.api_client.list_works = no_new_pages  # type: ignore[method-assign]
+    second.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+
+    await _drain_metadata_only_run(second)
+
+    checkpoint = second.checkpoint_manager.get()
+    assert fetches == ["W2"]
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.completed_work_ids == {"W1", "W2"}
+    assert second.page_tracker.state_store.list_manifests() == []
+    assert (tmp_path / "W2.json").exists()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,174 @@
+"""Tests for downloader orchestration safety boundaries."""
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from openalex_cli.api_client import WorkItem
+from openalex_cli.downloader import DownloadConfig, DownloadOrchestrator, QueuedWork
+from openalex_cli.progress import ProgressTracker
+from openalex_cli.utils import ContentFormat, StorageType
+
+
+class _DummyProgress:
+    def log_warning(self, message: str) -> None:
+        self.last_warning = message
+
+    def update_pagination(self, pages: int, cursor: str | None) -> None:
+        self.last_pagination = (pages, cursor)
+
+    def update_download(self, **kwargs) -> None:
+        self.last_download = kwargs
+
+    def log_info(self, message: str) -> None:
+        self.last_info = message
+
+    def log_error(self, message: str) -> None:
+        self.last_error = message
+
+
+@pytest.mark.asyncio
+async def test_metadata_failure_records_failed_result(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+    orchestrator._work_queue = asyncio.Queue()
+    orchestrator._results_queue = asyncio.Queue()
+
+    async def failing_metadata(work_id: str) -> dict[str, Any]:
+        del work_id
+        raise RuntimeError("metadata fetch failed")
+
+    orchestrator.api_client.get_work_metadata = failing_metadata  # type: ignore[method-assign]
+
+    await orchestrator._work_queue.put(QueuedWork(work=WorkItem(work_id="W1"), page_seq=7))
+    await orchestrator._work_queue.put(None)
+
+    await orchestrator._download_worker(0)
+
+    result = await orchestrator._results_queue.get()
+    assert result.work_id == "W1"
+    assert result.success is False
+    assert result.page_seq == 7
+    assert result.error is not None
+    assert "metadata fetch failed" in result.error
+
+
+@pytest.mark.asyncio
+async def test_producer_replays_pending_page_before_pagination(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    page = orchestrator.page_tracker.register_page("*", "cursor-1", ["W1", "W2"])
+    orchestrator._work_queue = asyncio.Queue()
+
+    async def empty_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format, cursor
+        if False:
+            yield [], None
+
+    orchestrator.api_client.list_works = empty_pages  # type: ignore[method-assign]
+
+    await orchestrator._produce_work()
+
+    queued = []
+    while not orchestrator._work_queue.empty():
+        item = await orchestrator._work_queue.get()
+        assert item is not None
+        queued.append((item.page_seq, item.work.work_id))
+
+    assert queued == [(page.seq, "W1"), (page.seq, "W2")]
+
+
+@pytest.mark.asyncio
+async def test_producer_resumes_fresh_pagination_after_highest_uncommitted_cursor(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.page_tracker.register_page("*", "cursor-1", ["W1"])
+    orchestrator.page_tracker.register_page("cursor-1", "cursor-2", ["W2"])
+    orchestrator._work_queue = asyncio.Queue()
+
+    seen_cursors = []
+
+    async def empty_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        seen_cursors.append(cursor)
+        if False:
+            yield [], None
+
+    orchestrator.api_client.list_works = empty_pages  # type: ignore[method-assign]
+
+    await orchestrator._produce_work()
+
+    assert seen_cursors == ["cursor-2"]
+
+
+@pytest.mark.asyncio
+async def test_run_commits_terminal_manifest_during_startup_reconcile(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.page_tracker.register_page("*", "cursor-1", ["W1"])
+    manifest = orchestrator.page_tracker.state_store.list_manifests()[0]
+    manifest.work_states["W1"].state = "completed"
+    manifest.work_states["W1"].file_size = 10
+    orchestrator.page_tracker.state_store.save_manifest(manifest)
+
+    async def empty_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format, cursor
+        if False:
+            yield [], None
+
+    orchestrator.api_client.list_works = empty_pages  # type: ignore[method-assign]
+    orchestrator.api_client.close = _async_noop  # type: ignore[method-assign]
+    orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
+
+    await orchestrator.run(orchestrator.progress_tracker)
+
+    checkpoint = orchestrator.checkpoint_manager.get()
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.pages_completed == 1
+    assert checkpoint.completed_work_ids == {"W1"}
+
+
+async def _async_noop():
+    return None

--- a/tests/test_page_tracker.py
+++ b/tests/test_page_tracker.py
@@ -1,0 +1,68 @@
+"""Tests for persisted page tracking."""
+
+from openalex_cli.checkpoint import CheckpointManager
+from openalex_cli.page_tracker import PageTracker
+
+
+def test_replay_only_pending_work_after_partial_page_completion(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    page = tracker.register_page("*", "cursor-1", ["W1", "W2", "W3"])
+    tracker.record_work_result(page.seq, "W1", True, 100, 0, None)
+    tracker.record_work_result(page.seq, "W2", False, 0, 0, "boom")
+
+    replay = tracker.replay_pending_work()
+    assert [(item.page_seq, item.work_id) for item in replay] == [(page.seq, "W3")]
+
+
+def test_terminal_pages_commit_in_order_even_if_results_arrive_out_of_order(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    page1 = tracker.register_page("*", "cursor-1", ["W1"])
+    page2 = tracker.register_page("cursor-1", "cursor-2", ["W2"])
+
+    commit = tracker.record_work_result(page2.seq, "W2", True, 20, 0, None)
+    assert commit.committed_pages == 0
+    assert manager.get().current_cursor == "*"
+
+    commit = tracker.record_work_result(page1.seq, "W1", True, 10, 0, None)
+    assert commit.committed_pages == 2
+    assert manager.get().current_cursor == "cursor-2"
+    assert manager.get().pages_completed == 2
+    assert manager.get().completed_work_ids == {"W1", "W2"}
+    assert tracker.replay_pending_work() == []
+
+
+def test_startup_reconcile_drops_stale_committed_manifest(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    page = tracker.register_page("*", "cursor-1", ["W1"])
+    tracker.record_work_result(page.seq, "W1", True, 10, 0, None)
+
+    stale = tracker.register_page("cursor-1", "cursor-2", ["W2"])
+    manifest = tracker.state_store.list_manifests()[0]
+    manifest.work_states["W2"].state = "completed"
+    manifest.work_states["W2"].file_size = 5
+    tracker.state_store.save_manifest(manifest)
+    manager.commit_page("cursor-2", [("W2", 5, 0)], [])
+
+    assert all(item.page_seq != stale.seq for item in tracker.replay_pending_work())
+    tracker.startup_reconcile()
+    assert tracker.replay_pending_work() == []
+
+
+def test_resume_cursor_uses_highest_uncommitted_cursor_out(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    tracker.register_page("*", "cursor-1", ["W1"])
+    tracker.register_page("cursor-1", "cursor-2", ["W2"])
+
+    assert tracker.resume_cursor("*") == "cursor-2"

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,7 +1,5 @@
 """Tests for adaptive rate limiter."""
 
-import asyncio
-
 import pytest
 
 from openalex_cli.rate_limiter import AdaptiveRateLimiter, APIHealth

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -25,8 +25,9 @@ class TestLocalStorage:
 
     async def test_get_full_path(self, storage):
         path = storage.get_full_path("test/file.pdf")
-        assert path.endswith("test/file.pdf")
-        assert Path(path).is_absolute()
+        path_obj = Path(path)
+        assert path_obj.is_absolute()
+        assert path_obj.parts[-2:] == ("test", "file.pdf")
 
     async def test_overwrite_existing(self, storage):
         await storage.save("test.pdf", b"original")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for utility functions."""
 
+from pathlib import Path
+
 import pytest
 
 from openalex_cli.utils import (
@@ -25,15 +27,15 @@ class TestWorkIdToPath:
 
     def test_nested_standard_work_id(self):
         path = work_id_to_path("W2741809807", "pdf", nested=True)
-        assert str(path) == "W27/41/W2741809807.pdf"
+        assert Path(path).parts == ("W27", "41", "W2741809807.pdf")
 
     def test_nested_short_work_id(self):
         path = work_id_to_path("W123", "pdf", nested=True)
-        assert str(path) == "W01/23/W123.pdf"
+        assert Path(path).parts == ("W01", "23", "W123.pdf")
 
     def test_nested_xml_extension(self):
         path = work_id_to_path("W2741809807", "tei.xml", nested=True)
-        assert str(path) == "W27/41/W2741809807.tei.xml"
+        assert Path(path).parts == ("W27", "41", "W2741809807.tei.xml")
 
 
 class TestParseWorkId:
@@ -94,10 +96,7 @@ class TestDoiToFilename:
         assert doi_to_filename("10.1038/nature12373") == "10.1038_nature12373"
 
     def test_doi_with_multiple_slashes(self):
-        assert (
-            doi_to_filename("10.1000/journal.pone.0000000")
-            == "10.1000_journal.pone.0000000"
-        )
+        assert doi_to_filename("10.1000/journal.pone.0000000") == "10.1000_journal.pone.0000000"
 
     def test_doi_with_colon(self):
         assert doi_to_filename("10.1234:example") == "10.1234_example"


### PR DESCRIPTION
## Summary

- persist per-page local state for metadata-only standard cursor downloads and replay unfinished admitted work before fresh pagination resumes
- delay durable cursor advancement until an admitted page becomes fully terminal instead of advancing on page admission
- add deterministic failpoints and restart integration tests so the new recovery behavior can be reviewed and smoke-tested explicitly

## Problem Before This Change

The downloader used to treat a listed page as effectively done as soon as it was queued.

That meant the control flow looked like this:

1. fetch page from OpenAlex
2. enqueue work IDs from that page in memory
3. immediately advance .openalex-checkpoint.json to the next cursor
4. later, workers fetch metadata and result processing marks work terminal

If the process stopped between steps 3 and 4, resume would start from the advanced cursor even though some works from the admitted page had never become terminal. Because that page membership only existed in memory, those works could be silently omitted.

## After This Change

The downloader now treats admitted pages and committed cursor progress as separate concepts.

The new flow is:

1. fetch page from OpenAlex
2. persist a local page manifest before admitting work
3. enqueue only the unfinished work IDs for that page
4. record per-work terminality against the manifest
5. advance the checkpoint cursor only when the page becomes fully terminal
6. on restart, replay unfinished work from persisted page manifests before fresh pagination resumes

## Logic Comparison

| Concern | Before | After |
| --- | --- | --- |
| Page membership | Existed only in memory after queue admission | Persisted locally in page manifests before queue admission |
| Cursor advancement | Happened immediately after listing a page | Happens only after a page becomes fully terminal |
| Resume source of truth | Checkpoint cursor plus committed work IDs | Checkpoint for committed history, page manifests for uncommitted pages |
| Interruption after admission | Could skip unfinished work from the last admitted page | Replays unfinished work from persisted page state |
| Metadata-only failure handling | Metadata fetch/write failures could still fall through toward success handling | Metadata-only failure is reported as failure and remains replayable |
| Restart verification | No deterministic way to force critical interruption boundaries | Failpoints now cover registration, replay, result recording, and page commit |

## What Changed

### Metadata-only page tracking

Standard cursor-based metadata downloads now persist local page manifests under the output directory before queue admission. Those manifests record admitted work IDs and their terminal state until the page is fully resolved.

Resume replays unfinished work from manifests first, then continues fresh pagination from the highest uncommitted manifest cursor rather than the last committed checkpoint cursor.

### Delayed cursor commit

The checkpoint cursor is no longer advanced when a page is merely listed. It advances only when the page becomes fully terminal and is committed as part of the contiguous committed prefix.

### Truthful metadata terminality

Metadata-only downloads now report failure if metadata fetch or metadata write fails, instead of falling through to a success path. That makes replay and commit decisions trustworthy.

### Durability and local-runtime hardening

Checkpoint and local file writes now use atomic replacement semantics.

The local-only code path no longer requires optional S3 dependencies just to import the downloader, and the downloader now tolerates Windows event loops that do not support dd_signal_handler().

### Failure-injection and restart coverage

This series adds controlled failpoints for:

- fter_replay_enqueue
- fter_page_register
- fter_result_record
- fter_page_commit

It also adds restart tests that prove metadata-only resume converges from persisted page state across separate orchestrator instances, including crashes:

- immediately after page registration
- after a work becomes terminal in a manifest but before the resumed page fully commits

## Scope

This PR intentionally scopes the safety redesign to:

- metadata-only downloads
- standard cursor pagination

## Non-Goals

This PR does not redesign:

- content-mode terminality for PDF/XML/BOTH
- sample-mode replay semantics
- explicit ID mode replay semantics
- broader retry behavior outside the existing downloader flow

## Validation

Ran the repo's configured quality gates:

`powershell
='src'; python -m ruff check src tests
='src'; python -m mypy src
='src'; pytest
`

Results:

- uff: passed
- mypy: passed
- pytest: passed (60 passed)