### PR TITLE
Consolidate downloader safety, retry, and progress fixes

### DIFF
--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -133,6 +133,37 @@ class OpenAlexAPIClient:
                 rate_limit_remaining=rate_limit_remaining,
             )
 
+    async def get_work_count(
+        self,
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+    ) -> int:
+        """Get a lightweight total count for a filtered works query."""
+        session = await self._get_session()
+
+        full_filter = filter_str
+        if content_format != ContentFormat.NONE:
+            if content_format in (ContentFormat.PDF, ContentFormat.BOTH):
+                content_filter = "has_content.pdf:true"
+            else:
+                content_filter = "has_content.grobid_xml:true"
+            full_filter = f"{content_filter},{filter_str}" if filter_str else content_filter
+
+        params: dict[str, str | int] = {
+            "per-page": 1,
+            "api_key": self.api_key,
+        }
+        if full_filter:
+            params["filter"] = full_filter
+
+        url = f"{self.WORKS_API_BASE}/works"
+        async with session.get(url, params=params) as response:
+            response.raise_for_status()
+            data = cast(dict[str, Any], await response.json())
+
+        meta = cast(dict[str, Any], data.get("meta", {}))
+        return int(meta.get("count", 0))
+
     async def list_works(
         self,
         filter_str: str | None = None,

--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -136,6 +136,8 @@ class OpenAlexAPIClient:
         filter_str: str | None = None,
         content_format: ContentFormat = ContentFormat.NONE,
         cursor: str = "*",
+        max_attempts: int = 3,
+        base_delay_seconds: float = 1.0,
     ) -> AsyncIterator[tuple[list[WorkItem], str | None]]:
         """
         List works using cursor pagination.
@@ -172,22 +174,31 @@ class OpenAlexAPIClient:
                 params["filter"] = full_filter
             url = f"{self.WORKS_API_BASE}/works"
 
-            async with session.get(url, params=params) as response:
-                if response.status == 429:
-                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
-                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
-                    if remaining < credits_required:
-                        raise CreditsExhaustedError(
-                            "Insufficient credits. Credits reset daily at midnight UTC."
+            attempt = 0
+            while True:
+                attempt += 1
+                async with session.get(url, params=params) as response:
+                    if response.status == 429:
+                        remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                        credits_required = int(
+                            response.headers.get("X-RateLimit-Credits-Required", 1)
                         )
-                    raise aiohttp.ClientResponseError(
-                        response.request_info,
-                        response.history,
-                        status=429,
-                        message="Rate limited",
-                    )
-                response.raise_for_status()
-                data = await response.json()
+                        if remaining < credits_required:
+                            raise CreditsExhaustedError(
+                                "Insufficient credits. Credits reset daily at midnight UTC."
+                            )
+                        if attempt >= max_attempts:
+                            raise aiohttp.ClientResponseError(
+                                response.request_info,
+                                response.history,
+                                status=429,
+                                message="Rate limited",
+                            )
+                        await asyncio.sleep(base_delay_seconds * (2 ** (attempt - 1)))
+                        continue
+                    response.raise_for_status()
+                    data = await response.json()
+                    break
 
             results = data.get("results", [])
             works = [WorkItem.from_api_response(r) for r in results]
@@ -207,6 +218,8 @@ class OpenAlexAPIClient:
         seed: int | None = None,
         filter_str: str | None = None,
         content_format: ContentFormat = ContentFormat.NONE,
+        max_attempts: int = 3,
+        base_delay_seconds: float = 1.0,
     ) -> AsyncIterator[list[WorkItem]]:
         """
         List a random sample of works using page-based pagination.
@@ -254,22 +267,31 @@ class OpenAlexAPIClient:
 
             url = f"{self.WORKS_API_BASE}/works"
 
-            async with session.get(url, params=params) as response:
-                if response.status == 429:
-                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
-                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
-                    if remaining < credits_required:
-                        raise CreditsExhaustedError(
-                            "Insufficient credits. Credits reset daily at midnight UTC."
+            attempt = 0
+            while True:
+                attempt += 1
+                async with session.get(url, params=params) as response:
+                    if response.status == 429:
+                        remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                        credits_required = int(
+                            response.headers.get("X-RateLimit-Credits-Required", 1)
                         )
-                    raise aiohttp.ClientResponseError(
-                        response.request_info,
-                        response.history,
-                        status=429,
-                        message="Rate limited",
-                    )
-                response.raise_for_status()
-                data = await response.json()
+                        if remaining < credits_required:
+                            raise CreditsExhaustedError(
+                                "Insufficient credits. Credits reset daily at midnight UTC."
+                            )
+                        if attempt >= max_attempts:
+                            raise aiohttp.ClientResponseError(
+                                response.request_info,
+                                response.history,
+                                status=429,
+                                message="Rate limited",
+                            )
+                        await asyncio.sleep(base_delay_seconds * (2 ** (attempt - 1)))
+                        continue
+                    response.raise_for_status()
+                    data = await response.json()
+                    break
 
             results = data.get("results", [])
             works = [WorkItem.from_api_response(r) for r in results]

--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -174,12 +174,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -241,6 +237,7 @@ class OpenAlexAPIClient:
                 full_filter = content_filter
 
         import math
+
         total_pages = math.ceil(sample_size / self.per_page)
 
         for page in range(1, total_pages + 1):
@@ -259,12 +256,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -319,12 +312,8 @@ class OpenAlexAPIClient:
                     )
 
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 0)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 0))
                     is_exhausted = remaining < credits_required
                     return DownloadResult(
                         work_id=work_id,
@@ -409,12 +398,8 @@ class OpenAlexAPIClient:
             if response.status == 404:
                 raise Exception(f"Work not found: {work_id}")
             if response.status == 429:
-                remaining = int(
-                    response.headers.get("X-RateLimit-Remaining", 0)
-                )
-                credits_required = int(
-                    response.headers.get("X-RateLimit-Credits-Required", 1)
-                )
+                remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                 if remaining < credits_required:
                     raise CreditsExhaustedError(
                         "Insufficient credits. Credits reset daily at midnight UTC."
@@ -427,6 +412,30 @@ class OpenAlexAPIClient:
                 )
             response.raise_for_status()
             return await response.json()
+
+    async def get_work_metadata_with_retry(
+        self,
+        work_id: str,
+        max_attempts: int = 3,
+        base_delay_seconds: float = 1.0,
+    ) -> dict:
+        """
+        Fetch full work metadata from the singleton API with bounded retry.
+
+        Retries HTTP 429 responses using a simple exponential backoff.
+        Credits exhaustion is treated as fatal and is not retried.
+        """
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                return await self.get_work_metadata(work_id)
+            except CreditsExhaustedError:
+                raise
+            except aiohttp.ClientResponseError as exc:
+                if exc.status != 429 or attempt >= max_attempts:
+                    raise
+                await asyncio.sleep(base_delay_seconds * (2 ** (attempt - 1)))
 
     async def resolve_dois(self, dois: list[str]) -> dict[str, str]:
         """

--- a/src/openalex_cli/api_client.py
+++ b/src/openalex_cli/api_client.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import AsyncIterator
+from typing import Any, cast
 
 import aiohttp
 
@@ -61,6 +62,7 @@ class DownloadResult:
     credits_cost: int = 0
     rate_limit_remaining: int | None = None
     file_size: int = 0
+    page_seq: int | None = None
 
 
 @dataclass
@@ -157,10 +159,7 @@ class OpenAlexAPIClient:
                 content_filter = "has_content.pdf:true"
             else:
                 content_filter = "has_content.grobid_xml:true"
-            if filter_str:
-                full_filter = f"{content_filter},{filter_str}"
-            else:
-                full_filter = content_filter
+            full_filter = f"{content_filter},{filter_str}" if filter_str else content_filter
 
         while cursor:
             params = {
@@ -174,12 +173,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -235,12 +230,10 @@ class OpenAlexAPIClient:
                 content_filter = "has_content.pdf:true"
             else:
                 content_filter = "has_content.grobid_xml:true"
-            if filter_str:
-                full_filter = f"{content_filter},{filter_str}"
-            else:
-                full_filter = content_filter
+            full_filter = f"{content_filter},{filter_str}" if filter_str else content_filter
 
         import math
+
         total_pages = math.ceil(sample_size / self.per_page)
 
         for page in range(1, total_pages + 1):
@@ -259,12 +252,8 @@ class OpenAlexAPIClient:
 
             async with session.get(url, params=params) as response:
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 1)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                     if remaining < credits_required:
                         raise CreditsExhaustedError(
                             "Insufficient credits. Credits reset daily at midnight UTC."
@@ -319,12 +308,8 @@ class OpenAlexAPIClient:
                     )
 
                 if response.status == 429:
-                    remaining = int(
-                        response.headers.get("X-RateLimit-Remaining", 0)
-                    )
-                    credits_required = int(
-                        response.headers.get("X-RateLimit-Credits-Required", 0)
-                    )
+                    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                    credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 0))
                     is_exhausted = remaining < credits_required
                     return DownloadResult(
                         work_id=work_id,
@@ -385,7 +370,7 @@ class OpenAlexAPIClient:
                 error="Request timed out",
             )
 
-    async def get_work_metadata(self, work_id: str) -> dict:
+    async def get_work_metadata(self, work_id: str) -> dict[str, Any]:
         """
         Fetch full work metadata from singleton API.
 
@@ -409,12 +394,8 @@ class OpenAlexAPIClient:
             if response.status == 404:
                 raise Exception(f"Work not found: {work_id}")
             if response.status == 429:
-                remaining = int(
-                    response.headers.get("X-RateLimit-Remaining", 0)
-                )
-                credits_required = int(
-                    response.headers.get("X-RateLimit-Credits-Required", 1)
-                )
+                remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+                credits_required = int(response.headers.get("X-RateLimit-Credits-Required", 1))
                 if remaining < credits_required:
                     raise CreditsExhaustedError(
                         "Insufficient credits. Credits reset daily at midnight UTC."
@@ -426,7 +407,7 @@ class OpenAlexAPIClient:
                     message="Rate limited",
                 )
             response.raise_for_status()
-            return await response.json()
+            return cast(dict[str, Any], await response.json())
 
     async def resolve_dois(self, dois: list[str]) -> dict[str, str]:
         """

--- a/src/openalex_cli/checkpoint.py
+++ b/src/openalex_cli/checkpoint.py
@@ -21,6 +21,7 @@ class DownloadStats:
     total_skipped: int = 0
     total_bytes: int = 0
     credits_used: int = 0
+    retry_count: int = 0
 
 
 @dataclass

--- a/src/openalex_cli/checkpoint.py
+++ b/src/openalex_cli/checkpoint.py
@@ -7,6 +7,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from .state_io import atomic_write_json
+
 
 @dataclass
 class DownloadStats:
@@ -109,7 +111,7 @@ class CheckpointManager:
                 data = json.load(f)
             self._checkpoint = Checkpoint.from_dict(data)
             return self._checkpoint
-        except (json.JSONDecodeError, KeyError) as e:
+        except (json.JSONDecodeError, KeyError):
             # Corrupted checkpoint - return None to start fresh
             return None
 
@@ -171,6 +173,37 @@ class CheckpointManager:
         """Check if a work ID has already been completed."""
         return work_id in self.get().completed_work_ids
 
+    def terminal_work_ids(self) -> set[str]:
+        """Return all work IDs with a committed terminal outcome."""
+        checkpoint = self.get()
+        return checkpoint.completed_work_ids | checkpoint.failed_work_ids
+
+    def commit_page(
+        self,
+        cursor: str | None,
+        completed_entries: list[tuple[str, int, int]],
+        failed_work_ids: list[str],
+    ) -> None:
+        """Commit a fully terminal page and advance the durable cursor."""
+        checkpoint = self.get()
+
+        for work_id, file_size, credits in completed_entries:
+            checkpoint.completed_work_ids.add(work_id)
+            checkpoint.failed_work_ids.discard(work_id)
+            checkpoint.stats.total_downloaded += 1
+            checkpoint.stats.total_bytes += file_size
+            checkpoint.stats.credits_used += credits
+
+        for work_id in failed_work_ids:
+            checkpoint.failed_work_ids.add(work_id)
+            checkpoint.stats.total_failed += 1
+
+        checkpoint.current_cursor = cursor or "*"
+        checkpoint.pages_completed += 1
+        checkpoint.stats.last_updated_at = time.time()
+        self._save()
+        self._pending_saves = 0
+
     def _maybe_save(self) -> None:
         """Save checkpoint if threshold reached."""
         self._pending_saves += 1
@@ -182,8 +215,7 @@ class CheckpointManager:
         """Save checkpoint to disk."""
         checkpoint = self.get()
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.checkpoint_path, "w") as f:
-            json.dump(checkpoint.to_dict(), f, indent=2)
+        atomic_write_json(self.checkpoint_path, checkpoint.to_dict())
 
     def force_save(self) -> None:
         """Force an immediate save (e.g., on shutdown)."""

--- a/src/openalex_cli/checkpoint.py
+++ b/src/openalex_cli/checkpoint.py
@@ -173,6 +173,28 @@ class CheckpointManager:
         """Check if a work ID has already been completed."""
         return work_id in self.get().completed_work_ids
 
+    def get_failed_work_ids(self) -> list[str]:
+        """Return unresolved failed work IDs in stable order."""
+        return sorted(self.get().failed_work_ids)
+
+    def resolve_failed_work(self, work_id: str, file_size: int, credits: int) -> None:
+        """Move a failed work into the completed set after a successful retry."""
+        checkpoint = self.get()
+        checkpoint.failed_work_ids.discard(work_id)
+        checkpoint.completed_work_ids.add(work_id)
+        checkpoint.stats.total_downloaded += 1
+        checkpoint.stats.total_bytes += file_size
+        checkpoint.stats.credits_used += credits
+        checkpoint.stats.last_updated_at = time.time()
+        self._maybe_save()
+
+    def record_failed_retry(self, work_id: str) -> None:
+        """Keep a failed work unresolved after another failed retry attempt."""
+        checkpoint = self.get()
+        checkpoint.failed_work_ids.add(work_id)
+        checkpoint.stats.last_updated_at = time.time()
+        self._maybe_save()
+
     def terminal_work_ids(self) -> set[str]:
         """Return all work IDs with a committed terminal outcome."""
         checkpoint = self.get()

--- a/src/openalex_cli/checkpoint.py
+++ b/src/openalex_cli/checkpoint.py
@@ -24,8 +24,67 @@ class DownloadStats:
 
 
 @dataclass
+class FilterCheckpoint:
+    """Per-filter checkpoint state for multi-filter downloads."""
+
+    id: str  # hash of filter string
+    name: str
+    filter_str: str
+    expected_total_works: int | None = None
+    current_cursor: str = "*"
+    pages_completed: int = 0
+    completed_work_ids: set[str] = field(default_factory=set)
+    failed_work_ids: set[str] = field(default_factory=set)
+    stats: DownloadStats = field(default_factory=DownloadStats)
+    status: str = "active"  # active, stalled, complete
+
+    def to_dict(self) -> dict:
+        """Convert to a JSON-serializable dict."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "filter_str": self.filter_str,
+            "expected_total_works": self.expected_total_works,
+            "current_cursor": self.current_cursor,
+            "pages_completed": self.pages_completed,
+            "completed_work_ids": list(self.completed_work_ids),
+            "failed_work_ids": list(self.failed_work_ids),
+            "stats": asdict(self.stats),
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> FilterCheckpoint:
+        """Create from a dict."""
+        stats_data = data.get("stats", {})
+        return cls(
+            id=data.get("id", ""),
+            name=data.get("name", ""),
+            filter_str=data.get("filter_str", ""),
+            expected_total_works=data.get("expected_total_works"),
+            current_cursor=data.get("current_cursor", "*"),
+            pages_completed=data.get("pages_completed", 0),
+            completed_work_ids=set(data.get("completed_work_ids", [])),
+            failed_work_ids=set(data.get("failed_work_ids", [])),
+            stats=DownloadStats(
+                started_at=stats_data.get("started_at", time.time()),
+                last_updated_at=stats_data.get("last_updated_at", time.time()),
+                total_downloaded=stats_data.get("total_downloaded", 0),
+                total_failed=stats_data.get("total_failed", 0),
+                total_skipped=stats_data.get("total_skipped", 0),
+                total_bytes=stats_data.get("total_bytes", 0),
+                credits_used=stats_data.get("credits_used", 0),
+            ),
+            status=data.get("status", "active"),
+        )
+
+
+@dataclass
 class Checkpoint:
     """Checkpoint state for resumable downloads."""
+
+    # Mode: "single" or "multi"
+    mode: str = "single"
 
     # Filter and format used for this download
     filter_str: str | None = None
@@ -45,9 +104,26 @@ class Checkpoint:
     # Statistics
     stats: DownloadStats = field(default_factory=DownloadStats)
 
+    # Multi-filter state
+    filters: list[FilterCheckpoint] = field(default_factory=list)
+
     def to_dict(self) -> dict:
         """Convert to a JSON-serializable dict."""
+        # For backward compatibility, single-mode checkpoints use old format
+        if self.mode == "single":
+            return {
+                "filter_str": self.filter_str,
+                "content_format": self.content_format,
+                "expected_total_works": self.expected_total_works,
+                "current_cursor": self.current_cursor,
+                "pages_completed": self.pages_completed,
+                "completed_work_ids": list(self.completed_work_ids),
+                "failed_work_ids": list(self.failed_work_ids),
+                "stats": asdict(self.stats),
+            }
+
         return {
+            "mode": self.mode,
             "filter_str": self.filter_str,
             "content_format": self.content_format,
             "expected_total_works": self.expected_total_works,
@@ -56,13 +132,24 @@ class Checkpoint:
             "completed_work_ids": list(self.completed_work_ids),
             "failed_work_ids": list(self.failed_work_ids),
             "stats": asdict(self.stats),
+            "filters": [f.to_dict() for f in self.filters],
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> Checkpoint:
         """Create from a dict."""
         stats_data = data.get("stats", {})
+
+        # Detect mode: if no 'mode' field, it's an old single-filter checkpoint
+        mode = data.get("mode", "single")
+
+        # Parse filters if present
+        filters = []
+        if "filters" in data:
+            filters = [FilterCheckpoint.from_dict(f) for f in data["filters"]]
+
         return cls(
+            mode=mode,
             filter_str=data.get("filter_str"),
             content_format=data.get("content_format", "pdf"),
             expected_total_works=data.get("expected_total_works"),
@@ -79,6 +166,7 @@ class Checkpoint:
                 total_bytes=stats_data.get("total_bytes", 0),
                 credits_used=stats_data.get("credits_used", 0),
             ),
+            filters=filters,
         )
 
 

--- a/src/openalex_cli/checkpoint.py
+++ b/src/openalex_cli/checkpoint.py
@@ -30,6 +30,7 @@ class Checkpoint:
     # Filter and format used for this download
     filter_str: str | None = None
     content_format: str = "pdf"
+    expected_total_works: int | None = None
 
     # Pagination state
     current_cursor: str = "*"
@@ -49,6 +50,7 @@ class Checkpoint:
         return {
             "filter_str": self.filter_str,
             "content_format": self.content_format,
+            "expected_total_works": self.expected_total_works,
             "current_cursor": self.current_cursor,
             "pages_completed": self.pages_completed,
             "completed_work_ids": list(self.completed_work_ids),
@@ -63,6 +65,7 @@ class Checkpoint:
         return cls(
             filter_str=data.get("filter_str"),
             content_format=data.get("content_format", "pdf"),
+            expected_total_works=data.get("expected_total_works"),
             current_cursor=data.get("current_cursor", "*"),
             pages_completed=data.get("pages_completed", 0),
             completed_work_ids=set(data.get("completed_work_ids", [])),
@@ -119,11 +122,13 @@ class CheckpointManager:
         self,
         filter_str: str | None = None,
         content_format: str = "pdf",
+        expected_total_works: int | None = None,
     ) -> Checkpoint:
         """Create a new checkpoint."""
         self._checkpoint = Checkpoint(
             filter_str=filter_str,
             content_format=content_format,
+            expected_total_works=expected_total_works,
         )
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self._save()

--- a/src/openalex_cli/cli.py
+++ b/src/openalex_cli/cli.py
@@ -135,8 +135,20 @@ def main() -> None:
 )
 @click.option(
     "--filter",
-    "filter_str",
-    help="OpenAlex filter string (e.g., 'publication_year:>2020,type:article')",
+    "filter_strs",
+    multiple=True,
+    help="OpenAlex filter string (e.g., 'publication_year:>2020,type:article'). Can be specified multiple times.",
+)
+@click.option(
+    "--filters-file",
+    "filters_file",
+    type=click.Path(exists=True),
+    help="Path to a file containing filter strings (one per line for .txt, or JSON array for .json)",
+)
+@click.option(
+    "--resume-filter",
+    "resume_filter",
+    help="Resume a specific filter by name (requires multi-filter checkpoint)",
 )
 @click.option(
     "--content",
@@ -215,7 +227,9 @@ def download(
     storage: str,
     s3_bucket: str | None,
     s3_prefix: str,
-    filter_str: str | None,
+    filter_strs: tuple[str, ...],
+    filters_file: str | None,
+    resume_filter: str | None,
     content_types: str | None,
     nested: bool,
     ids_str: str | None,
@@ -267,6 +281,21 @@ def download(
         raise click.UsageError("--retry-workers requires --retry-failed")
     if retry_workers is not None and retry_workers <= 0:
         raise click.UsageError("--retry-workers must be greater than 0")
+
+    # Parse and validate filters
+    filters: list[str] = []
+    if filters_file and filter_strs:
+        raise click.UsageError("Cannot use both --filters-file and --filter. Choose one.")
+    if filters_file:
+        # TODO: Implement filters file parsing in Commit 2
+        raise click.UsageError("--filters-file not yet implemented. Use --filter for now.")
+    if filter_strs:
+        filters = list(filter_strs)
+    if resume_filter and len(filters) <= 1:
+        raise click.UsageError("--resume-filter requires multiple filters.")
+
+    # For backward compatibility, use single filter mode if only one filter
+    filter_str = filters[0] if len(filters) == 1 else None
 
     # Parse IDs from stdin or --ids option
     work_ids: list[str] | None = None

--- a/src/openalex_cli/cli.py
+++ b/src/openalex_cli/cli.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from pathlib import Path
 
 import click
 
 from . import __version__
 from .api_client import OpenAlexAPIClient
-from .downloader import DownloadConfig, DownloadOrchestrator
+from .downloader import DownloadConfig, DownloadOrchestrator, MultiFilterOrchestrator
 from .progress import ProgressTracker
 from .utils import ContentFormat, StorageType, parse_identifier
 
@@ -283,19 +284,48 @@ def download(
         raise click.UsageError("--retry-workers must be greater than 0")
 
     # Parse and validate filters
-    filters: list[str] = []
+    filters: list[dict] = []
     if filters_file and filter_strs:
         raise click.UsageError("Cannot use both --filters-file and --filter. Choose one.")
     if filters_file:
-        # TODO: Implement filters file parsing in Commit 2
-        raise click.UsageError("--filters-file not yet implemented. Use --filter for now.")
+        from .filters import auto_convert_txt_to_json, parse_filters_file
+
+        filters_path = Path(filters_file)
+        try:
+            filters = parse_filters_file(filters_path)
+            # Auto-convert .txt to .json sidecar
+            if filters_path.suffix.lower() == ".txt":
+                json_path = auto_convert_txt_to_json(filters_path)
+                if not quiet:
+                    click.echo(f"Auto-generated filter config: {json_path}")
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
     if filter_strs:
-        filters = list(filter_strs)
+        from .filters import _generate_filter_id
+
+        for i, filter_str in enumerate(filter_strs, 1):
+            filters.append(
+                {
+                    "id": _generate_filter_id(filter_str),
+                    "name": f"filter_{i:03d}",
+                    "filter": filter_str,
+                }
+            )
     if resume_filter and len(filters) <= 1:
         raise click.UsageError("--resume-filter requires multiple filters.")
 
+    # Validate filters if in multi-filter mode
+    if len(filters) > 1 and not quiet:
+        click.echo(f"Validating {len(filters)} filters...")
+        from .filters import validate_filters
+
+        filters = asyncio.run(validate_filters(filters, api_key))
+        if not filters:
+            raise click.UsageError("No valid filters found. Check your filter syntax.")
+        click.echo(f"{len(filters)} filters validated successfully.")
+
     # For backward compatibility, use single filter mode if only one filter
-    filter_str = filters[0] if len(filters) == 1 else None
+    single_filter: str | None = str(filters[0]["filter"]) if len(filters) == 1 else None
 
     # Parse IDs from stdin or --ids option
     work_ids: list[str] | None = None
@@ -340,7 +370,7 @@ def download(
             raise click.UsageError("--retry-failed is not supported with --stdin")
 
     # Warn if no filter and no IDs provided
-    if not filter_str and not work_ids:
+    if not single_filter and not work_ids:
         # Detect piped stdin without --stdin flag
         if not sys.stdin.isatty() and not use_stdin:
             click.echo(
@@ -369,7 +399,7 @@ def download(
         storage_type=StorageType.S3 if storage == "s3" else StorageType.LOCAL,
         s3_bucket=s3_bucket,
         s3_prefix=s3_prefix,
-        filter_str=filter_str,
+        filter_str=single_filter,
         content_format=content_format,
         workers=workers,
         resume=resume,
@@ -392,8 +422,28 @@ def download(
         verbose=verbose,
     )
 
-    # Create orchestrator and run
-    orchestrator = DownloadOrchestrator(config)
+    # Route to multi-filter or single-filter orchestrator
+    orchestrator: MultiFilterOrchestrator | DownloadOrchestrator
+    if len(filters) > 1:
+        # Multi-filter mode
+        orchestrator = MultiFilterOrchestrator(
+            api_key=api_key,
+            output_path=output,
+            filters=filters,
+            content_format=content_format,
+            workers=workers,
+            resume=resume,
+            fresh=fresh,
+            quiet=quiet,
+            verbose=verbose,
+            nested=nested,
+            retry_failed=retry_failed,
+            retry_workers=retry_workers,
+            resume_filter=resume_filter,
+        )
+    else:
+        # Single-filter mode (backward compatible)
+        orchestrator = DownloadOrchestrator(config)
 
     try:
         progress.start()
@@ -403,7 +453,9 @@ def download(
     finally:
         progress.stop()
 
-    if orchestrator._credits_exhausted:
+    # Check credits exhausted (works for both orchestrator types)
+    credits_exhausted = getattr(orchestrator, "_credits_exhausted", False)
+    if credits_exhausted:
         sys.exit(1)
 
 

--- a/src/openalex_cli/cli.py
+++ b/src/openalex_cli/cli.py
@@ -81,8 +81,7 @@ async def _resolve_identifiers(
                     original_map[work_id] = doi  # Remember original DOI for filename
                 elif not quiet:
                     click.echo(
-                        click.style("Warning: ", fg="yellow")
-                        + f"DOI not found in OpenAlex: {doi}"
+                        click.style("Warning: ", fg="yellow") + f"DOI not found in OpenAlex: {doi}"
                     )
         finally:
             await client.close()
@@ -260,20 +259,15 @@ def download(
         raw_ids = _parse_input_ids(ids_str, use_stdin)
         if not raw_ids:
             click.echo(
-                click.style("Error: ", fg="red")
-                + "No work IDs provided. Check your input.",
+                click.style("Error: ", fg="red") + "No work IDs provided. Check your input.",
                 err=True,
             )
             if use_stdin:
                 click.echo("  stdin was empty — verify your pipe or input file.", err=True)
             sys.exit(1)
-        work_ids, original_identifiers = asyncio.run(
-            _resolve_identifiers(raw_ids, api_key, quiet)
-        )
+        work_ids, original_identifiers = asyncio.run(_resolve_identifiers(raw_ids, api_key, quiet))
         if not work_ids:
-            click.echo(
-                click.style("Error: ", fg="red") + "No valid work IDs found.", err=True
-            )
+            click.echo(click.style("Error: ", fg="red") + "No valid work IDs found.", err=True)
             sys.exit(1)
         if not quiet:
             click.echo(f"Found {len(work_ids)} work(s) to download.")
@@ -282,9 +276,7 @@ def download(
     content_format = ContentFormat.NONE
     if content_types:
         types = [t.strip().lower() for t in content_types.split(",")]
-        if "pdf" in types and "xml" in types:
-            content_format = ContentFormat.BOTH
-        elif "both" in types:
+        if ("pdf" in types and "xml" in types) or "both" in types:
             content_format = ContentFormat.BOTH
         elif "pdf" in types:
             content_format = ContentFormat.PDF
@@ -372,7 +364,7 @@ def status(api_key: str) -> None:
         client = OpenAlexAPIClient(api_key=api_key)
         try:
             status = await client.get_status()
-            click.echo(f"API Key Status:")
+            click.echo("API Key Status:")
             click.echo(f"  Rate limit remaining: {status.rate_limit_remaining:,}")
             click.echo()
             click.echo("Note: Full credit information requires a premium API key.")

--- a/src/openalex_cli/cli.py
+++ b/src/openalex_cli/cli.py
@@ -166,6 +166,17 @@ def main() -> None:
     type=click.IntRange(1, 200),
 )
 @click.option(
+    "--retry-failed",
+    is_flag=True,
+    help="Retry unresolved failed metadata downloads after the main run.",
+)
+@click.option(
+    "--retry-workers",
+    type=int,
+    default=None,
+    help="Worker count for the failed-ID retry phase.",
+)
+@click.option(
     "--resume/--no-resume",
     default=True,
     help="Resume from checkpoint if available",
@@ -210,6 +221,8 @@ def download(
     ids_str: str | None,
     use_stdin: bool,
     workers: int,
+    retry_failed: bool,
+    retry_workers: int | None,
     resume: bool,
     fresh: bool,
     sample_size: int | None,
@@ -250,6 +263,10 @@ def download(
         raise click.UsageError("--sample cannot be used with --ids or --stdin")
     if seed is not None and not sample_size:
         raise click.UsageError("--seed requires --sample")
+    if retry_workers is not None and not retry_failed:
+        raise click.UsageError("--retry-workers requires --retry-failed")
+    if retry_workers is not None and retry_workers <= 0:
+        raise click.UsageError("--retry-workers must be greater than 0")
 
     # Parse IDs from stdin or --ids option
     work_ids: list[str] | None = None
@@ -282,6 +299,16 @@ def download(
             content_format = ContentFormat.PDF
         elif "xml" in types:
             content_format = ContentFormat.XML
+
+    if retry_failed:
+        if content_format != ContentFormat.NONE:
+            raise click.UsageError("--retry-failed currently supports metadata-only downloads only")
+        if sample_size:
+            raise click.UsageError("--retry-failed is not supported with --sample")
+        if ids_str:
+            raise click.UsageError("--retry-failed is not supported with --ids")
+        if use_stdin:
+            raise click.UsageError("--retry-failed is not supported with --stdin")
 
     # Warn if no filter and no IDs provided
     if not filter_str and not work_ids:
@@ -325,6 +352,8 @@ def download(
         original_identifiers=original_identifiers,
         sample=sample_size,
         seed=seed,
+        retry_failed=retry_failed,
+        retry_workers=retry_workers,
     )
 
     # Create progress tracker

--- a/src/openalex_cli/cli.py
+++ b/src/openalex_cli/cli.py
@@ -314,12 +314,16 @@ def download(
     if resume_filter and len(filters) <= 1:
         raise click.UsageError("--resume-filter requires multiple filters.")
 
-    # Validate filters if in multi-filter mode
-    if len(filters) > 1 and not quiet:
+    # Validate all filters (both file-based and inline)
+    if filters and not quiet:
         click.echo(f"Validating {len(filters)} filters...")
         from .filters import validate_filters
 
-        filters = asyncio.run(validate_filters(filters, api_key))
+        # Create temporary progress tracker for validation logging
+        validation_progress = ProgressTracker(output_dir=output, quiet=quiet, verbose=verbose)
+        filters = asyncio.run(
+            validate_filters(filters, api_key, progress_tracker=validation_progress)
+        )
         if not filters:
             raise click.UsageError("No valid filters found. Check your filter syntax.")
         click.echo(f"{len(filters)} filters validated successfully.")

--- a/src/openalex_cli/cli.py
+++ b/src/openalex_cli/cli.py
@@ -319,11 +319,7 @@ def download(
         click.echo(f"Validating {len(filters)} filters...")
         from .filters import validate_filters
 
-        # Create temporary progress tracker for validation logging
-        validation_progress = ProgressTracker(output_dir=output, quiet=quiet, verbose=verbose)
-        filters = asyncio.run(
-            validate_filters(filters, api_key, progress_tracker=validation_progress)
-        )
+        filters = asyncio.run(validate_filters(filters, api_key, progress_tracker=None))
         if not filters:
             raise click.UsageError("No valid filters found. Check your filter syntax.")
         click.echo(f"{len(filters)} filters validated successfully.")

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -861,21 +861,39 @@ class MultiFilterOrchestrator:
         for filter_config in filters_to_run:
             filter_name = filter_config.get("name", "unnamed")
             filter_str = filter_config.get("filter", "")
+            filter_id = filter_config.get("id", "")
 
             if progress_tracker:
                 progress_tracker.log_info(f"Starting filter: {filter_name}")
 
-            # Check if this filter is already complete
+            # Find existing filter by ID (hash-based matching)
             existing_filter = None
             for f in checkpoint.filters:
-                if f.filter_str == filter_str:
+                if f.id == filter_id:
                     existing_filter = f
                     break
 
-            if existing_filter and existing_filter.status == "complete":
-                if progress_tracker:
-                    progress_tracker.log_info(f"Filter '{filter_name}' already complete, skipping")
-                continue
+            # Handle stalled filters: retry them automatically
+            if existing_filter:
+                if existing_filter.status == "complete":
+                    if progress_tracker:
+                        progress_tracker.log_info(
+                            f"Filter '{filter_name}' already complete, skipping"
+                        )
+                    continue
+                elif existing_filter.status == "stalled":
+                    retry_count = getattr(existing_filter.stats, "retry_count", 0)
+                    if retry_count >= 3:
+                        if progress_tracker:
+                            progress_tracker.log_warning(
+                                f"Filter '{filter_name}' stalled after {retry_count} retries, skipping"
+                            )
+                        continue
+                    if progress_tracker:
+                        progress_tracker.log_info(
+                            f"Filter '{filter_name}' was stalled, retrying (attempt {retry_count + 1}/3)"
+                        )
+                    existing_filter.status = "active"
 
             # Create config for this filter
             config = DownloadConfig(
@@ -905,32 +923,45 @@ class MultiFilterOrchestrator:
                     progress_tracker.log_error(
                         f"Filter '{filter_name}' failed: {e}. Continuing with next filter."
                     )
-                # Mark filter as stalled
+                # Mark filter as stalled and increment retry count
                 if existing_filter:
                     existing_filter.status = "stalled"
+                    existing_filter.stats.retry_count = (
+                        getattr(existing_filter.stats, "retry_count", 0) + 1
+                    )
                 else:
                     from .checkpoint import FilterCheckpoint
 
                     new_filter = FilterCheckpoint(
-                        id=filter_config.get("id", ""),
+                        id=filter_id,
                         name=filter_name,
                         filter_str=filter_str,
                         status="stalled",
                     )
+                    new_filter.stats.retry_count = 1
                     checkpoint.filters.append(new_filter)
                 checkpoint_manager.force_save()
                 continue
 
-            # Mark filter as complete
+            # Sync per-filter state from child orchestrator
+            child_checkpoint = orchestrator.checkpoint_manager.get()
             if existing_filter:
+                existing_filter.completed_work_ids.update(child_checkpoint.completed_work_ids)
+                existing_filter.failed_work_ids.update(child_checkpoint.failed_work_ids)
+                existing_filter.current_cursor = child_checkpoint.current_cursor
+                existing_filter.pages_completed = child_checkpoint.pages_completed
                 existing_filter.status = "complete"
             else:
                 from .checkpoint import FilterCheckpoint
 
                 new_filter = FilterCheckpoint(
-                    id=filter_config.get("id", ""),
+                    id=filter_id,
                     name=filter_name,
                     filter_str=filter_str,
+                    completed_work_ids=set(child_checkpoint.completed_work_ids),
+                    failed_work_ids=set(child_checkpoint.failed_work_ids),
+                    current_cursor=child_checkpoint.current_cursor,
+                    pages_completed=child_checkpoint.pages_completed,
                     status="complete",
                 )
                 checkpoint.filters.append(new_filter)

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -41,6 +41,8 @@ class DownloadConfig:
     original_identifiers: dict[str, str] | None = None  # Maps work_id -> original input (e.g., DOI)
     sample: int | None = None  # Random sample size (max 10,000)
     seed: int | None = None  # Seed for reproducible random samples
+    retry_failed: bool = False
+    retry_workers: int | None = None
 
 
 @dataclass
@@ -88,6 +90,7 @@ class DownloadOrchestrator:
         # Control flags
         self._shutdown_requested = False
         self._credits_exhausted = False
+        self._retry_failed_phase = False
         self._page_tracking_enabled = (
             self.config.content_format == ContentFormat.NONE
             and not self.config.sample
@@ -172,6 +175,13 @@ class DownloadOrchestrator:
             )
             await result_processor
 
+            if (
+                self.config.retry_failed
+                and not self._shutdown_requested
+                and not self._credits_exhausted
+            ):
+                await self._run_failed_retry_phase()
+
         finally:
             # Clean up
             if self._page_tracking_enabled:
@@ -206,6 +216,10 @@ class DownloadOrchestrator:
                 "Purchase more at https://openalex.org/pricing. "
                 "Progress has been saved — use --resume to continue later."
             )
+
+    def _get_retry_workers(self) -> int:
+        """Return worker count for the failed-ID retry phase."""
+        return self.config.retry_workers or 10
 
     def _setup_checkpoint(self):
         """Set up or resume checkpoint."""
@@ -402,37 +416,81 @@ class DownloadOrchestrator:
         if not self.config.work_ids:
             return
 
-        # Fetch metadata for each work ID from the list API
-        # We need basic info like has_pdf/has_xml
         for work_id in self.config.work_ids:
             if self._shutdown_requested:
                 break
 
-            # Skip already completed
             if self.checkpoint_manager.is_completed(work_id):
                 continue
 
-            try:
-                # Fetch work metadata from singleton API
-                metadata = await self.api_client.get_work_metadata_with_retry(work_id)
-                work = WorkItem.from_api_response(metadata)
-                assert self._work_queue is not None
-                await self._work_queue.put(QueuedWork(work=work))
-            except CreditsExhaustedError:
-                self._handle_credits_exhausted()
-                break
-            except Exception as e:
-                if self.progress_tracker:
-                    self.progress_tracker.log_error(f"Error fetching metadata for {work_id}: {e}")
-                assert self._results_queue is not None
-                await self._results_queue.put(
-                    DownloadResult(
-                        work_id=work_id,
-                        format=ContentFormat.NONE,
-                        success=False,
-                        error=f"Failed to fetch metadata: {e}",
-                    )
-                )
+            assert self._work_queue is not None
+            await self._work_queue.put(QueuedWork(work=WorkItem(work_id=work_id)))
+
+    async def _run_direct_work_id_phase(self, work_ids: list[str], workers: int) -> None:
+        """Run a work-list phase using direct work IDs and existing worker/result logic."""
+        self._work_queue = asyncio.Queue()
+        self._results_queue = asyncio.Queue()
+
+        worker_tasks = [asyncio.create_task(self._download_worker(i)) for i in range(workers)]
+        result_processor = asyncio.create_task(self._process_results())
+
+        try:
+            for work_id in work_ids:
+                if self._shutdown_requested:
+                    break
+
+                if self.checkpoint_manager.is_completed(work_id):
+                    continue
+
+                await self._work_queue.put(QueuedWork(work=WorkItem(work_id=work_id)))
+
+            for _ in range(workers):
+                await self._work_queue.put(None)
+
+            await asyncio.gather(*worker_tasks)
+
+            await self._results_queue.put(
+                DownloadResult(work_id="__DONE__", format=ContentFormat.NONE, success=True)
+            )
+            await result_processor
+        finally:
+            for task in worker_tasks:
+                if not task.done():
+                    task.cancel()
+            if not result_processor.done():
+                result_processor.cancel()
+
+    async def _run_failed_retry_phase(self) -> None:
+        """Retry unresolved failed metadata downloads using a smaller worker pool."""
+        failed_ids = self.checkpoint_manager.get_failed_work_ids()
+        if not failed_ids:
+            if self.progress_tracker:
+                self.progress_tracker.log_info("No failed works to retry.")
+            return
+
+        retry_workers = self._get_retry_workers()
+
+        if self.progress_tracker:
+            self.progress_tracker.log_info(
+                f"Retrying {len(failed_ids)} failed works with {retry_workers} workers"
+            )
+
+        self._retry_failed_phase = True
+        try:
+            await self._run_direct_work_id_phase(
+                work_ids=failed_ids,
+                workers=retry_workers,
+            )
+        finally:
+            self._retry_failed_phase = False
+
+        remaining = len(self.checkpoint_manager.get_failed_work_ids())
+        recovered = len(failed_ids) - remaining
+
+        if self.progress_tracker:
+            self.progress_tracker.log_info(
+                f"Retry complete: recovered {recovered}, remaining failed {remaining}"
+            )
 
     async def _download_worker(self, worker_id: int) -> None:
         """Worker that downloads metadata and optionally content."""
@@ -599,14 +657,24 @@ class DownloadOrchestrator:
                     )
                     self.failure_injector.hit("after_page_commit")
             else:
-                if result.success:
-                    self.checkpoint_manager.mark_completed(
-                        result.work_id,
-                        result.file_size,
-                        result.credits_cost,
-                    )
+                if self._retry_failed_phase:
+                    if result.success:
+                        self.checkpoint_manager.resolve_failed_work(
+                            result.work_id,
+                            result.file_size,
+                            result.credits_cost,
+                        )
+                    else:
+                        self.checkpoint_manager.record_failed_retry(result.work_id)
                 else:
-                    self.checkpoint_manager.mark_failed(result.work_id)
+                    if result.success:
+                        self.checkpoint_manager.mark_completed(
+                            result.work_id,
+                            result.file_size,
+                            result.credits_cost,
+                        )
+                    else:
+                        self.checkpoint_manager.mark_failed(result.work_id)
 
             if self.progress_tracker:
                 self.progress_tracker.update_download(

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -131,6 +131,7 @@ class DownloadOrchestrator:
                     starting_completed=len(checkpoint.completed_work_ids),
                     expected_total_works=checkpoint.expected_total_works,
                 )
+                self._sync_progress_checkpoint_state()
 
             if self._page_tracking_enabled:
                 commit = self.page_tracker.startup_reconcile()
@@ -236,6 +237,17 @@ class DownloadOrchestrator:
             and not self.config.work_ids
         )
 
+    def _sync_progress_checkpoint_state(self) -> None:
+        """Sync progress display from durable checkpoint state."""
+        if not self.progress_tracker:
+            return
+
+        checkpoint = self.checkpoint_manager.get()
+        self.progress_tracker.sync_checkpoint_state(
+            completed_count=len(checkpoint.completed_work_ids),
+            unresolved_failed_count=len(checkpoint.failed_work_ids),
+        )
+
     async def _setup_checkpoint(self):
         """Set up or resume checkpoint."""
         # Check for existing checkpoint
@@ -286,14 +298,15 @@ class DownloadOrchestrator:
                                 )
 
                     if self.progress_tracker:
-                        stats = existing.stats
+                        completed = len(existing.completed_work_ids)
+                        unresolved_failed = len(existing.failed_work_ids)
                         expected_total = existing.expected_total_works
                         total_suffix = (
                             f" of {expected_total:,} expected" if expected_total is not None else ""
                         )
                         self.progress_tracker.log_info(
-                            f"Resuming from checkpoint: {stats.total_downloaded} downloaded, "
-                            f"{stats.total_failed} failed{total_suffix}"
+                            f"Resuming from checkpoint: {completed} completed, "
+                            f"{unresolved_failed} unresolved failed{total_suffix}"
                         )
                     return existing
 
@@ -528,10 +541,12 @@ class DownloadOrchestrator:
             return
 
         retry_workers = self._get_retry_workers()
+        original_rate_limiter = self.rate_limiter
+        self.rate_limiter = AdaptiveRateLimiter(max_workers=retry_workers)
 
         if self.progress_tracker:
             self.progress_tracker.log_info(
-                f"Retrying {len(failed_ids)} failed works with {retry_workers} workers"
+                f"Retrying {len(failed_ids)} unresolved failed works with {retry_workers} workers"
             )
 
         self._retry_failed_phase = True
@@ -542,13 +557,14 @@ class DownloadOrchestrator:
             )
         finally:
             self._retry_failed_phase = False
+            self.rate_limiter = original_rate_limiter
 
         remaining = len(self.checkpoint_manager.get_failed_work_ids())
         recovered = len(failed_ids) - remaining
 
         if self.progress_tracker:
             self.progress_tracker.log_info(
-                f"Retry complete: recovered {recovered}, remaining failed {remaining}"
+                f"Retry phase complete: recovered {recovered}, remaining unresolved {remaining}"
             )
 
     async def _download_worker(self, worker_id: int) -> None:
@@ -715,6 +731,7 @@ class DownloadOrchestrator:
                         cursor=commit.current_cursor,
                     )
                     self.failure_injector.hit("after_page_commit")
+                self._sync_progress_checkpoint_state()
             else:
                 if self._retry_failed_phase:
                     if result.success:
@@ -734,6 +751,7 @@ class DownloadOrchestrator:
                         )
                     else:
                         self.checkpoint_manager.mark_failed(result.work_id)
+                self._sync_progress_checkpoint_state()
 
             if self.progress_tracker:
                 self.progress_tracker.update_download(

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -857,6 +857,21 @@ class MultiFilterOrchestrator:
                     )
                 return
 
+        # Check for orphaned filters (in checkpoint but not in config)
+        config_filter_ids = {f.get("id", "") for f in self.filters}
+        orphaned_filters = []
+        for cp_filter in checkpoint.filters:
+            if cp_filter.id not in config_filter_ids and cp_filter.status != "orphaned":
+                orphaned_filters.append(cp_filter)
+                cp_filter.status = "orphaned"
+
+        if orphaned_filters and progress_tracker:
+            names = [f.name for f in orphaned_filters]
+            progress_tracker.log_warning(
+                f"Orphaned filters detected (removed from config): {', '.join(names)}"
+            )
+            checkpoint_manager.force_save()
+
         # Run each filter
         for filter_config in filters_to_run:
             filter_name = filter_config.get("name", "unnamed")

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -122,9 +122,15 @@ class DownloadOrchestrator:
 
         try:
             # Initialize or resume checkpoint
-            checkpoint = self._setup_checkpoint()
+            checkpoint = await self._setup_checkpoint()
             if checkpoint is None:
                 return
+
+            if self.progress_tracker:
+                self.progress_tracker.initialize_totals(
+                    starting_completed=len(checkpoint.completed_work_ids),
+                    expected_total_works=checkpoint.expected_total_works,
+                )
 
             if self._page_tracking_enabled:
                 commit = self.page_tracker.startup_reconcile()
@@ -221,7 +227,16 @@ class DownloadOrchestrator:
         """Return worker count for the failed-ID retry phase."""
         return self.config.retry_workers or 10
 
-    def _setup_checkpoint(self):
+    def _should_prefetch_total_count(self) -> bool:
+        """Return True when this run should do a one-shot total count preflight."""
+        return (
+            self.config.content_format == ContentFormat.NONE
+            and self.config.filter_str is not None
+            and not self.config.sample
+            and not self.config.work_ids
+        )
+
+    async def _setup_checkpoint(self):
         """Set up or resume checkpoint."""
         # Check for existing checkpoint
         if self.checkpoint_manager.exists() and not self.config.fresh:
@@ -248,18 +263,62 @@ class DownloadOrchestrator:
                     return None
 
                 if self.config.resume:
+                    if (
+                        existing.expected_total_works is None
+                        and self._should_prefetch_total_count()
+                    ):
+                        try:
+                            existing.expected_total_works = await self.api_client.get_work_count(
+                                filter_str=self.config.filter_str,
+                                content_format=self.config.content_format,
+                            )
+                            self.checkpoint_manager.force_save()
+                            if self.progress_tracker:
+                                self.progress_tracker.log_info(
+                                    "Backfilled expected total works for this existing checkpoint: "
+                                    f"{existing.expected_total_works:,}"
+                                )
+                        except Exception as e:
+                            if self.progress_tracker:
+                                self.progress_tracker.log_warning(
+                                    "Could not backfill total work count for this existing checkpoint: "
+                                    f"{e}"
+                                )
+
                     if self.progress_tracker:
                         stats = existing.stats
+                        expected_total = existing.expected_total_works
+                        total_suffix = (
+                            f" of {expected_total:,} expected" if expected_total is not None else ""
+                        )
                         self.progress_tracker.log_info(
                             f"Resuming from checkpoint: {stats.total_downloaded} downloaded, "
-                            f"{stats.total_failed} failed"
+                            f"{stats.total_failed} failed{total_suffix}"
                         )
                     return existing
 
         # Create new checkpoint
+        expected_total_works = None
+        if self._should_prefetch_total_count():
+            try:
+                expected_total_works = await self.api_client.get_work_count(
+                    filter_str=self.config.filter_str,
+                    content_format=self.config.content_format,
+                )
+                if self.progress_tracker:
+                    self.progress_tracker.log_info(
+                        f"Estimated total works for this download: {expected_total_works:,}"
+                    )
+            except Exception as e:
+                if self.progress_tracker:
+                    self.progress_tracker.log_warning(
+                        f"Could not determine total work count for progress estimation: {e}"
+                    )
+
         return self.checkpoint_manager.create(
             filter_str=self.config.filter_str,
             content_format=self.config.content_format.value,
+            expected_total_works=expected_total_works,
         )
 
     async def _produce_work(self) -> None:

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -111,8 +111,7 @@ class DownloadOrchestrator:
 
             # Start worker tasks
             workers = [
-                asyncio.create_task(self._download_worker(i))
-                for i in range(self.config.workers)
+                asyncio.create_task(self._download_worker(i)) for i in range(self.config.workers)
             ]
 
             # Start result processor
@@ -154,9 +153,7 @@ class DownloadOrchestrator:
             raise KeyboardInterrupt()
         self._shutdown_requested = True
         if self.progress_tracker:
-            self.progress_tracker.log_warning(
-                "Shutdown requested. Finishing current downloads..."
-            )
+            self.progress_tracker.log_warning("Shutdown requested. Finishing current downloads...")
 
     def _handle_credits_exhausted(self) -> None:
         """Stop all work when credits are exhausted."""
@@ -317,9 +314,7 @@ class DownloadOrchestrator:
                     await self._work_queue.put(work)
 
                 if self.progress_tracker:
-                    self.progress_tracker.log_info(
-                        f"Queued {total_count} works from sample..."
-                    )
+                    self.progress_tracker.log_info(f"Queued {total_count} works from sample...")
 
         except CreditsExhaustedError:
             self._handle_credits_exhausted()
@@ -344,12 +339,23 @@ class DownloadOrchestrator:
 
             try:
                 # Fetch work metadata from singleton API
-                metadata = await self.api_client.get_work_metadata(work_id)
+                metadata = await self.api_client.get_work_metadata_with_retry(work_id)
                 work = WorkItem.from_api_response(metadata)
                 await self._work_queue.put(work)
+            except CreditsExhaustedError:
+                self._handle_credits_exhausted()
+                break
             except Exception as e:
                 if self.progress_tracker:
                     self.progress_tracker.log_error(f"Error fetching metadata for {work_id}: {e}")
+                await self._results_queue.put(
+                    DownloadResult(
+                        work_id=work_id,
+                        format=ContentFormat.NONE,
+                        success=False,
+                        error=f"Failed to fetch metadata: {e}",
+                    )
+                )
 
     async def _download_worker(self, worker_id: int) -> None:
         """Worker that downloads metadata and optionally content."""
@@ -374,21 +380,24 @@ class DownloadOrchestrator:
                     filename_base = doi_to_filename(orig)
 
             # Always save full metadata (fetch from singleton API)
+            meta_content = b""
             try:
-                full_metadata = await self.api_client.get_work_metadata(work.work_id)
-                meta_path = str(
-                    work_id_to_path(filename_base, "json", nested=self.config.nested)
-                )
+                full_metadata = await self.api_client.get_work_metadata_with_retry(work.work_id)
+                meta_path = str(work_id_to_path(filename_base, "json", nested=self.config.nested))
                 meta_content = json.dumps(full_metadata, indent=2).encode()
                 await self.storage.save(meta_path, meta_content, "application/json")
             except CreditsExhaustedError:
                 self._handle_credits_exhausted()
                 break
             except Exception as e:
-                if self.progress_tracker:
-                    self.progress_tracker.log_warning(
-                        f"Failed to fetch metadata for {work.work_id}: {e}"
-                    )
+                result = DownloadResult(
+                    work_id=work.work_id,
+                    format=ContentFormat.NONE,
+                    success=False,
+                    error=f"Failed to fetch metadata: {e}",
+                )
+                await self._results_queue.put(result)
+                continue
 
             # If no content requested, we're done with this work
             if self.config.content_format == ContentFormat.NONE:

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -6,11 +6,13 @@ import asyncio
 import json
 import signal
 import time
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Callable
 
 from .api_client import CreditsExhaustedError, DownloadResult, OpenAlexAPIClient, WorkItem
 from .checkpoint import CheckpointManager
+from .fault_injection import FailureInjector
 from .page_tracker import PageTracker
 from .progress import ProgressTracker
 from .rate_limiter import AdaptiveRateLimiter
@@ -65,6 +67,7 @@ class DownloadOrchestrator:
         self.rate_limiter = AdaptiveRateLimiter(max_workers=config.workers)
         self.checkpoint_manager = CheckpointManager(config.output_path)
         self.page_tracker = PageTracker(config.output_path, self.checkpoint_manager)
+        self.failure_injector = FailureInjector()
         self.progress_tracker: ProgressTracker | None = None
 
         # Initialize storage backend
@@ -269,14 +272,18 @@ class DownloadOrchestrator:
                         page_seq=replay.page_seq,
                     )
                 )
+                self.failure_injector.hit("after_replay_enqueue")
             cursor = self.page_tracker.resume_cursor(cursor) or cursor
 
+        page_iter = self.api_client.list_works(
+            filter_str=self.config.filter_str,
+            content_format=self.config.content_format,
+            cursor=cursor,
+        )
+        closable_page_iter = page_iter if isinstance(page_iter, AsyncGenerator) else None
+
         try:
-            async for works, next_cursor in self.api_client.list_works(
-                filter_str=self.config.filter_str,
-                content_format=self.config.content_format,
-                cursor=cursor,
-            ):
+            async for works, next_cursor in page_iter:
                 if self._shutdown_requested:
                     break
 
@@ -305,6 +312,7 @@ class DownloadOrchestrator:
                         cursor_out=next_cursor,
                         work_ids=work_ids,
                     ).seq
+                    self.failure_injector.hit("after_page_register")
 
                 for work in queueable_works:
                     if self._shutdown_requested:
@@ -329,6 +337,10 @@ class DownloadOrchestrator:
         except Exception as e:
             if self.progress_tracker:
                 self.progress_tracker.log_error(f"Error listing works: {e}")
+            raise
+        finally:
+            if closable_page_iter is not None:
+                await closable_page_iter.aclose()
 
     async def _produce_work_from_sample(self) -> None:
         """Queue work items from a random sample (page-based pagination)."""
@@ -568,11 +580,13 @@ class DownloadOrchestrator:
                     credits=result.credits_cost,
                     error=result.error,
                 )
+                self.failure_injector.hit("after_result_record")
                 if self.progress_tracker and commit.committed_pages:
                     self.progress_tracker.update_pagination(
                         pages=commit.pages_completed,
                         cursor=commit.current_cursor,
                     )
+                    self.failure_injector.hit("after_page_commit")
             else:
                 if result.success:
                     self.checkpoint_manager.mark_completed(

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -865,11 +865,12 @@ class MultiFilterOrchestrator:
                 orphaned_filters.append(cp_filter)
                 cp_filter.status = "orphaned"
 
-        if orphaned_filters and progress_tracker:
-            names = [f.name for f in orphaned_filters]
-            progress_tracker.log_warning(
-                f"Orphaned filters detected (removed from config): {', '.join(names)}"
-            )
+        if orphaned_filters:
+            if progress_tracker:
+                names = [f.name for f in orphaned_filters]
+                progress_tracker.log_warning(
+                    f"Orphaned filters detected (removed from config): {', '.join(names)}"
+                )
             checkpoint_manager.force_save()
 
         # Run each filter
@@ -938,6 +939,10 @@ class MultiFilterOrchestrator:
                     progress_tracker.log_error(
                         f"Filter '{filter_name}' failed: {e}. Continuing with next filter."
                     )
+                # Reload checkpoint to get child's partial progress
+                checkpoint_manager.load()
+                checkpoint = checkpoint_manager.get()
+
                 # Mark filter as stalled and increment retry count
                 if existing_filter:
                     existing_filter.status = "stalled"
@@ -957,6 +962,17 @@ class MultiFilterOrchestrator:
                     checkpoint.filters.append(new_filter)
                 checkpoint_manager.force_save()
                 continue
+
+            # Reload checkpoint to get child's final state (avoids race condition)
+            checkpoint_manager.load()
+            checkpoint = checkpoint_manager.get()
+
+            # Re-find existing filter after reload
+            existing_filter = None
+            for f in checkpoint.filters:
+                if f.id == filter_id:
+                    existing_filter = f
+                    break
 
             # Sync per-filter state from child orchestrator
             child_checkpoint = orchestrator.checkpoint_manager.get()

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -133,6 +133,13 @@ class DownloadOrchestrator:
                 )
                 self._sync_progress_checkpoint_state()
 
+            if self._should_exit_without_work(checkpoint):
+                if self.progress_tracker:
+                    self.progress_tracker.log_info(
+                        "Nothing left to download; checkpoint already covers all expected works."
+                    )
+                return
+
             if self._page_tracking_enabled:
                 commit = self.page_tracker.startup_reconcile()
                 if self.progress_tracker and commit.committed_pages:
@@ -246,6 +253,24 @@ class DownloadOrchestrator:
         self.progress_tracker.sync_checkpoint_state(
             completed_count=len(checkpoint.completed_work_ids),
             unresolved_failed_count=len(checkpoint.failed_work_ids),
+        )
+
+    def _should_exit_without_work(self, checkpoint) -> bool:
+        """Return True when resume state proves this run has no work left to do."""
+        if checkpoint.failed_work_ids and self.config.retry_failed:
+            return False
+
+        if self.config.work_ids:
+            return all(
+                self.checkpoint_manager.is_completed(work_id) for work_id in self.config.work_ids
+            )
+
+        expected_total = checkpoint.expected_total_works
+        if expected_total is None:
+            return False
+
+        return (
+            len(checkpoint.completed_work_ids) >= expected_total and not checkpoint.failed_work_ids
         )
 
     async def _setup_checkpoint(self):
@@ -563,6 +588,11 @@ class DownloadOrchestrator:
         recovered = len(failed_ids) - remaining
 
         if self.progress_tracker:
+            self.progress_tracker.record_retry_summary(
+                attempted=len(failed_ids),
+                recovered=recovered,
+                remaining=remaining,
+            )
             self.progress_tracker.log_info(
                 f"Retry phase complete: recovered {recovered}, remaining unresolved {remaining}"
             )

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -791,3 +791,153 @@ class DownloadOrchestrator:
                     error=result.error,
                     rate_limiter_state=self.rate_limiter.get_state(),
                 )
+
+
+class MultiFilterOrchestrator:
+    """Orchestrates multiple filter downloads into a single output directory."""
+
+    def __init__(
+        self,
+        api_key: str,
+        output_path: str,
+        filters: list[dict],
+        content_format: ContentFormat = ContentFormat.NONE,
+        workers: int = 50,
+        resume: bool = True,
+        fresh: bool = False,
+        quiet: bool = False,
+        verbose: bool = False,
+        nested: bool = False,
+        retry_failed: bool = False,
+        retry_workers: int | None = None,
+        resume_filter: str | None = None,
+    ):
+        self.api_key = api_key
+        self.output_path = output_path
+        self.filters = filters
+        self.content_format = content_format
+        self.workers = workers
+        self.resume = resume
+        self.fresh = fresh
+        self.quiet = quiet
+        self.verbose = verbose
+        self.nested = nested
+        self.retry_failed = retry_failed
+        self.retry_workers = retry_workers
+        self.resume_filter = resume_filter
+
+    async def run(self, progress_tracker: ProgressTracker | None = None) -> None:
+        """Run downloads for all filters."""
+        from .checkpoint import CheckpointManager
+
+        checkpoint_manager = CheckpointManager(self.output_path)
+
+        # Load or create checkpoint
+        if checkpoint_manager.exists() and not self.fresh:
+            checkpoint = checkpoint_manager.load()
+        else:
+            checkpoint = None
+
+        if checkpoint is None:
+            # Create new multi-filter checkpoint
+            from .checkpoint import Checkpoint
+
+            checkpoint = Checkpoint(mode="multi")
+            checkpoint_manager._checkpoint = checkpoint
+            checkpoint_manager.force_save()
+
+        # If resume_filter specified, only run that filter
+        filters_to_run = self.filters
+        if self.resume_filter:
+            filters_to_run = [f for f in self.filters if f.get("name") == self.resume_filter]
+            if not filters_to_run:
+                if progress_tracker:
+                    progress_tracker.log_error(
+                        f"Filter '{self.resume_filter}' not found in configuration"
+                    )
+                return
+
+        # Run each filter
+        for filter_config in filters_to_run:
+            filter_name = filter_config.get("name", "unnamed")
+            filter_str = filter_config.get("filter", "")
+
+            if progress_tracker:
+                progress_tracker.log_info(f"Starting filter: {filter_name}")
+
+            # Check if this filter is already complete
+            existing_filter = None
+            for f in checkpoint.filters:
+                if f.filter_str == filter_str:
+                    existing_filter = f
+                    break
+
+            if existing_filter and existing_filter.status == "complete":
+                if progress_tracker:
+                    progress_tracker.log_info(f"Filter '{filter_name}' already complete, skipping")
+                continue
+
+            # Create config for this filter
+            config = DownloadConfig(
+                api_key=self.api_key,
+                output_path=self.output_path,
+                filter_str=filter_str,
+                content_format=self.content_format,
+                workers=self.workers,
+                resume=self.resume,
+                fresh=self.fresh,
+                quiet=self.quiet,
+                verbose=self.verbose,
+                nested=self.nested,
+                retry_failed=self.retry_failed,
+                retry_workers=self.retry_workers,
+            )
+
+            # Create orchestrator and run
+            orchestrator = DownloadOrchestrator(config)
+
+            try:
+                if progress_tracker:
+                    progress_tracker.set_current_filter(filter_name)
+                await orchestrator.run(progress_tracker=progress_tracker)
+            except Exception as e:
+                if progress_tracker:
+                    progress_tracker.log_error(
+                        f"Filter '{filter_name}' failed: {e}. Continuing with next filter."
+                    )
+                # Mark filter as stalled
+                if existing_filter:
+                    existing_filter.status = "stalled"
+                else:
+                    from .checkpoint import FilterCheckpoint
+
+                    new_filter = FilterCheckpoint(
+                        id=filter_config.get("id", ""),
+                        name=filter_name,
+                        filter_str=filter_str,
+                        status="stalled",
+                    )
+                    checkpoint.filters.append(new_filter)
+                checkpoint_manager.force_save()
+                continue
+
+            # Mark filter as complete
+            if existing_filter:
+                existing_filter.status = "complete"
+            else:
+                from .checkpoint import FilterCheckpoint
+
+                new_filter = FilterCheckpoint(
+                    id=filter_config.get("id", ""),
+                    name=filter_name,
+                    filter_str=filter_str,
+                    status="complete",
+                )
+                checkpoint.filters.append(new_filter)
+            checkpoint_manager.force_save()
+
+            if progress_tracker:
+                progress_tracker.log_info(f"Filter '{filter_name}' complete")
+
+        if progress_tracker:
+            progress_tracker.set_current_filter(None)

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -84,10 +84,16 @@ class DownloadOrchestrator:
         self._work_queue = asyncio.Queue()
         self._results_queue = asyncio.Queue()
 
-        # Set up signal handlers for graceful shutdown
+        # Set up signal handlers for graceful shutdown.
+        # Windows event loops do not support add_signal_handler().
         loop = asyncio.get_running_loop()
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, self._request_shutdown)
+        signal_handlers_installed = False
+        try:
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, self._request_shutdown)
+            signal_handlers_installed = True
+        except NotImplementedError:
+            pass
 
         try:
             # Initialize or resume checkpoint
@@ -111,8 +117,7 @@ class DownloadOrchestrator:
 
             # Start worker tasks
             workers = [
-                asyncio.create_task(self._download_worker(i))
-                for i in range(self.config.workers)
+                asyncio.create_task(self._download_worker(i)) for i in range(self.config.workers)
             ]
 
             # Start result processor
@@ -143,9 +148,10 @@ class DownloadOrchestrator:
             await self.api_client.close()
             await self.storage.close()
 
-            # Remove signal handlers
-            for sig in (signal.SIGINT, signal.SIGTERM):
-                loop.remove_signal_handler(sig)
+            # Remove signal handlers only if they were installed.
+            if signal_handlers_installed:
+                for sig in (signal.SIGINT, signal.SIGTERM):
+                    loop.remove_signal_handler(sig)
 
     def _request_shutdown(self) -> None:
         """Handle shutdown signal."""
@@ -154,9 +160,7 @@ class DownloadOrchestrator:
             raise KeyboardInterrupt()
         self._shutdown_requested = True
         if self.progress_tracker:
-            self.progress_tracker.log_warning(
-                "Shutdown requested. Finishing current downloads..."
-            )
+            self.progress_tracker.log_warning("Shutdown requested. Finishing current downloads...")
 
     def _handle_credits_exhausted(self) -> None:
         """Stop all work when credits are exhausted."""
@@ -317,9 +321,7 @@ class DownloadOrchestrator:
                     await self._work_queue.put(work)
 
                 if self.progress_tracker:
-                    self.progress_tracker.log_info(
-                        f"Queued {total_count} works from sample..."
-                    )
+                    self.progress_tracker.log_info(f"Queued {total_count} works from sample...")
 
         except CreditsExhaustedError:
             self._handle_credits_exhausted()
@@ -376,9 +378,7 @@ class DownloadOrchestrator:
             # Always save full metadata (fetch from singleton API)
             try:
                 full_metadata = await self.api_client.get_work_metadata(work.work_id)
-                meta_path = str(
-                    work_id_to_path(filename_base, "json", nested=self.config.nested)
-                )
+                meta_path = str(work_id_to_path(filename_base, "json", nested=self.config.nested))
                 meta_content = json.dumps(full_metadata, indent=2).encode()
                 await self.storage.save(meta_path, meta_content, "application/json")
             except CreditsExhaustedError:

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -7,11 +7,11 @@ import json
 import signal
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Callable
 
 from .api_client import CreditsExhaustedError, DownloadResult, OpenAlexAPIClient, WorkItem
 from .checkpoint import CheckpointManager
+from .page_tracker import PageTracker
 from .progress import ProgressTracker
 from .rate_limiter import AdaptiveRateLimiter
 from .storage import LocalStorage, S3Storage, StorageBackend
@@ -41,6 +41,14 @@ class DownloadConfig:
     seed: int | None = None  # Seed for reproducible random samples
 
 
+@dataclass
+class QueuedWork:
+    """Work queued for download with optional page-tracking context."""
+
+    work: WorkItem
+    page_seq: int | None = None
+
+
 class DownloadOrchestrator:
     """Orchestrates the bulk download process."""
 
@@ -56,12 +64,17 @@ class DownloadOrchestrator:
         self.api_client = OpenAlexAPIClient(api_key=config.api_key)
         self.rate_limiter = AdaptiveRateLimiter(max_workers=config.workers)
         self.checkpoint_manager = CheckpointManager(config.output_path)
+        self.page_tracker = PageTracker(config.output_path, self.checkpoint_manager)
         self.progress_tracker: ProgressTracker | None = None
 
         # Initialize storage backend
         if config.storage_type == StorageType.S3:
             if not config.s3_bucket:
                 raise ValueError("S3 bucket required for S3 storage")
+            if S3Storage is None:
+                raise RuntimeError(
+                    "S3 storage requires the optional aiobotocore dependency to be installed"
+                )
             self.storage: StorageBackend = S3Storage(
                 bucket=config.s3_bucket,
                 prefix=config.s3_prefix,
@@ -72,8 +85,13 @@ class DownloadOrchestrator:
         # Control flags
         self._shutdown_requested = False
         self._credits_exhausted = False
+        self._page_tracking_enabled = (
+            self.config.content_format == ContentFormat.NONE
+            and not self.config.sample
+            and not self.config.work_ids
+        )
         # Queues are created in run() to ensure they're in the correct event loop
-        self._work_queue: asyncio.Queue[WorkItem | None] | None = None
+        self._work_queue: asyncio.Queue[QueuedWork | None] | None = None
         self._results_queue: asyncio.Queue[DownloadResult] | None = None
 
     async def run(self, progress_tracker: ProgressTracker | None = None) -> None:
@@ -86,14 +104,28 @@ class DownloadOrchestrator:
 
         # Set up signal handlers for graceful shutdown
         loop = asyncio.get_running_loop()
+        signal_handlers_installed = False
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, self._request_shutdown)
+            try:
+                loop.add_signal_handler(sig, self._request_shutdown)
+                signal_handlers_installed = True
+            except NotImplementedError:
+                signal_handlers_installed = False
+                break
 
         try:
             # Initialize or resume checkpoint
             checkpoint = self._setup_checkpoint()
             if checkpoint is None:
                 return
+
+            if self._page_tracking_enabled:
+                commit = self.page_tracker.startup_reconcile()
+                if self.progress_tracker and commit.committed_pages:
+                    self.progress_tracker.update_pagination(
+                        pages=commit.pages_completed,
+                        cursor=commit.current_cursor,
+                    )
 
             # Log start
             if self.progress_tracker:
@@ -111,8 +143,7 @@ class DownloadOrchestrator:
 
             # Start worker tasks
             workers = [
-                asyncio.create_task(self._download_worker(i))
-                for i in range(self.config.workers)
+                asyncio.create_task(self._download_worker(i)) for i in range(self.config.workers)
             ]
 
             # Start result processor
@@ -144,8 +175,9 @@ class DownloadOrchestrator:
             await self.storage.close()
 
             # Remove signal handlers
-            for sig in (signal.SIGINT, signal.SIGTERM):
-                loop.remove_signal_handler(sig)
+            if signal_handlers_installed:
+                for sig in (signal.SIGINT, signal.SIGTERM):
+                    loop.remove_signal_handler(sig)
 
     def _request_shutdown(self) -> None:
         """Handle shutdown signal."""
@@ -154,9 +186,7 @@ class DownloadOrchestrator:
             raise KeyboardInterrupt()
         self._shutdown_requested = True
         if self.progress_tracker:
-            self.progress_tracker.log_warning(
-                "Shutdown requested. Finishing current downloads..."
-            )
+            self.progress_tracker.log_warning("Shutdown requested. Finishing current downloads...")
 
     def _handle_credits_exhausted(self) -> None:
         """Stop all work when credits are exhausted."""
@@ -230,6 +260,17 @@ class DownloadOrchestrator:
         warned_about_flat = False
         total_count = 0
 
+        if self._page_tracking_enabled:
+            assert self._work_queue is not None
+            for replay in self.page_tracker.replay_pending_work():
+                await self._work_queue.put(
+                    QueuedWork(
+                        work=WorkItem(work_id=replay.work_id),
+                        page_seq=replay.page_seq,
+                    )
+                )
+            cursor = self.page_tracker.resume_cursor(cursor) or cursor
+
         try:
             async for works, next_cursor in self.api_client.list_works(
                 filter_str=self.config.filter_str,
@@ -253,24 +294,35 @@ class DownloadOrchestrator:
                     )
                     warned_about_flat = True
 
-                for work in works:
+                page_seq: int | None = None
+                queueable_works = [
+                    work for work in works if not self.checkpoint_manager.is_completed(work.work_id)
+                ]
+                work_ids = [work.work_id for work in queueable_works]
+                if self._page_tracking_enabled and work_ids:
+                    page_seq = self.page_tracker.register_page(
+                        cursor_in=cursor,
+                        cursor_out=next_cursor,
+                        work_ids=work_ids,
+                    ).seq
+
+                for work in queueable_works:
                     if self._shutdown_requested:
                         break
 
-                    # Skip already completed
-                    if self.checkpoint_manager.is_completed(work.work_id):
-                        continue
+                    assert self._work_queue is not None
+                    await self._work_queue.put(QueuedWork(work=work, page_seq=page_seq))
 
-                    await self._work_queue.put(work)
+                if not self._page_tracking_enabled:
+                    self.checkpoint_manager.update_cursor(next_cursor)
 
-                # Update cursor checkpoint
-                self.checkpoint_manager.update_cursor(next_cursor)
-
-                if self.progress_tracker:
+                if self.progress_tracker and not self._page_tracking_enabled:
                     self.progress_tracker.update_pagination(
                         pages=checkpoint.pages_completed,
                         cursor=next_cursor,
                     )
+
+                cursor = next_cursor or "*"
 
         except CreditsExhaustedError:
             self._handle_credits_exhausted()
@@ -282,10 +334,14 @@ class DownloadOrchestrator:
         """Queue work items from a random sample (page-based pagination)."""
         total_count = 0
         warned_about_flat = False
+        sample_size = self.config.sample
+
+        if sample_size is None:
+            return
 
         try:
             async for works in self.api_client.list_works_sample(
-                sample_size=self.config.sample,
+                sample_size=sample_size,
                 seed=self.config.seed,
                 filter_str=self.config.filter_str,
                 content_format=self.config.content_format,
@@ -314,12 +370,11 @@ class DownloadOrchestrator:
                     if self.checkpoint_manager.is_completed(work.work_id):
                         continue
 
-                    await self._work_queue.put(work)
+                    assert self._work_queue is not None
+                    await self._work_queue.put(QueuedWork(work=work))
 
                 if self.progress_tracker:
-                    self.progress_tracker.log_info(
-                        f"Queued {total_count} works from sample..."
-                    )
+                    self.progress_tracker.log_info(f"Queued {total_count} works from sample...")
 
         except CreditsExhaustedError:
             self._handle_credits_exhausted()
@@ -346,7 +401,8 @@ class DownloadOrchestrator:
                 # Fetch work metadata from singleton API
                 metadata = await self.api_client.get_work_metadata(work_id)
                 work = WorkItem.from_api_response(metadata)
-                await self._work_queue.put(work)
+                assert self._work_queue is not None
+                await self._work_queue.put(QueuedWork(work=work))
             except Exception as e:
                 if self.progress_tracker:
                     self.progress_tracker.log_error(f"Error fetching metadata for {work_id}: {e}")
@@ -355,12 +411,15 @@ class DownloadOrchestrator:
         """Worker that downloads metadata and optionally content."""
         while not self._shutdown_requested:
             try:
-                work = await asyncio.wait_for(self._work_queue.get(), timeout=1.0)
+                assert self._work_queue is not None
+                queued = await asyncio.wait_for(self._work_queue.get(), timeout=1.0)
             except asyncio.TimeoutError:
                 continue
 
-            if work is None:
+            if queued is None:
                 break
+
+            work = queued.work
 
             # Determine filename base: use original DOI if provided, else work_id
             filename_base = work.work_id
@@ -376,9 +435,7 @@ class DownloadOrchestrator:
             # Always save full metadata (fetch from singleton API)
             try:
                 full_metadata = await self.api_client.get_work_metadata(work.work_id)
-                meta_path = str(
-                    work_id_to_path(filename_base, "json", nested=self.config.nested)
-                )
+                meta_path = str(work_id_to_path(filename_base, "json", nested=self.config.nested))
                 meta_content = json.dumps(full_metadata, indent=2).encode()
                 await self.storage.save(meta_path, meta_content, "application/json")
             except CreditsExhaustedError:
@@ -390,6 +447,19 @@ class DownloadOrchestrator:
                         f"Failed to fetch metadata for {work.work_id}: {e}"
                     )
 
+                if self.config.content_format == ContentFormat.NONE:
+                    assert self._results_queue is not None
+                    await self._results_queue.put(
+                        DownloadResult(
+                            work_id=work.work_id,
+                            format=ContentFormat.NONE,
+                            success=False,
+                            error=str(e),
+                            page_seq=queued.page_seq,
+                        )
+                    )
+                continue
+
             # If no content requested, we're done with this work
             if self.config.content_format == ContentFormat.NONE:
                 # Report success for metadata-only download
@@ -397,20 +467,26 @@ class DownloadOrchestrator:
                     work_id=work.work_id,
                     format=ContentFormat.NONE,
                     success=True,
-                    file_size=len(meta_content) if meta_content else 0,
+                    file_size=len(meta_content),
                     credits_cost=0,  # Singleton API is free
+                    page_seq=queued.page_seq,
                 )
+                assert self._results_queue is not None
                 await self._results_queue.put(result)
                 continue
 
             # Determine content formats to download
             formats = []
-            if self.config.content_format in (ContentFormat.PDF, ContentFormat.BOTH):
-                if work.has_pdf:
-                    formats.append(ContentFormat.PDF)
-            if self.config.content_format in (ContentFormat.XML, ContentFormat.BOTH):
-                if work.has_xml:
-                    formats.append(ContentFormat.XML)
+            if (
+                self.config.content_format in (ContentFormat.PDF, ContentFormat.BOTH)
+                and work.has_pdf
+            ):
+                formats.append(ContentFormat.PDF)
+            if (
+                self.config.content_format in (ContentFormat.XML, ContentFormat.BOTH)
+                and work.has_xml
+            ):
+                formats.append(ContentFormat.XML)
 
             # If no content available for requested formats, report success (metadata was saved)
             if not formats:
@@ -418,9 +494,11 @@ class DownloadOrchestrator:
                     work_id=work.work_id,
                     format=self.config.content_format,
                     success=True,
-                    file_size=len(meta_content) if meta_content else 0,
+                    file_size=len(meta_content),
                     credits_cost=0,
+                    page_seq=queued.page_seq,
                 )
+                assert self._results_queue is not None
                 await self._results_queue.put(result)
                 continue
 
@@ -454,6 +532,8 @@ class DownloadOrchestrator:
                         )
                         await self.storage.save(path, result.content, content_type)
 
+                    result.page_seq = queued.page_seq
+                    assert self._results_queue is not None
                     await self._results_queue.put(result)
 
                 except Exception as e:
@@ -462,7 +542,9 @@ class DownloadOrchestrator:
                         format=fmt,
                         success=False,
                         error=str(e),
+                        page_seq=queued.page_seq,
                     )
+                    assert self._results_queue is not None
                     await self._results_queue.put(result)
 
                 finally:
@@ -471,19 +553,35 @@ class DownloadOrchestrator:
     async def _process_results(self) -> None:
         """Process download results and update progress."""
         while True:
+            assert self._results_queue is not None
             result = await self._results_queue.get()
 
             if result.work_id == "__DONE__":
                 break
 
-            if result.success:
-                self.checkpoint_manager.mark_completed(
-                    result.work_id,
-                    result.file_size,
-                    result.credits_cost,
+            if self._page_tracking_enabled and result.page_seq is not None:
+                commit = self.page_tracker.record_work_result(
+                    page_seq=result.page_seq,
+                    work_id=result.work_id,
+                    success=result.success,
+                    file_size=result.file_size,
+                    credits=result.credits_cost,
+                    error=result.error,
                 )
+                if self.progress_tracker and commit.committed_pages:
+                    self.progress_tracker.update_pagination(
+                        pages=commit.pages_completed,
+                        cursor=commit.current_cursor,
+                    )
             else:
-                self.checkpoint_manager.mark_failed(result.work_id)
+                if result.success:
+                    self.checkpoint_manager.mark_completed(
+                        result.work_id,
+                        result.file_size,
+                        result.credits_cost,
+                    )
+                else:
+                    self.checkpoint_manager.mark_failed(result.work_id)
 
             if self.progress_tracker:
                 self.progress_tracker.update_download(

--- a/src/openalex_cli/downloader.py
+++ b/src/openalex_cli/downloader.py
@@ -174,6 +174,8 @@ class DownloadOrchestrator:
 
         finally:
             # Clean up
+            if self._page_tracking_enabled:
+                self.page_tracker.flush_dirty_manifests()
             self.checkpoint_manager.force_save()
             await self.api_client.close()
             await self.storage.close()
@@ -588,6 +590,7 @@ class DownloadOrchestrator:
                     credits=result.credits_cost,
                     error=result.error,
                 )
+                self.page_tracker.flush_manifest(result.page_seq)
                 self.failure_injector.hit("after_result_record")
                 if self.progress_tracker and commit.committed_pages:
                     self.progress_tracker.update_pagination(

--- a/src/openalex_cli/fault_injection.py
+++ b/src/openalex_cli/fault_injection.py
@@ -1,0 +1,58 @@
+"""Controlled failure hooks for smoke-testing downloader recovery."""
+
+from __future__ import annotations
+
+import os
+
+
+class InjectedFailure(RuntimeError):
+    """Raised when a configured failure hook is triggered."""
+
+
+class FailureInjector:
+    """One-shot failure injection controlled by environment variables."""
+
+    POINTS_ENV = "OPENALEX_FAILPOINTS"
+    COUNTS_ENV = "OPENALEX_FAILCOUNTS"
+
+    def __init__(self) -> None:
+        self._points = self._parse_points(os.getenv(self.POINTS_ENV, ""))
+        self._counts = self._parse_counts(os.getenv(self.COUNTS_ENV, ""))
+        self._hits: dict[str, int] = {}
+
+    def hit(self, point: str) -> None:
+        """Trigger a configured failure once the failpoint threshold is reached."""
+        if point not in self._points:
+            return
+
+        hit_count = self._hits.get(point, 0) + 1
+        self._hits[point] = hit_count
+        target = self._counts.get(point, 1)
+        if hit_count >= target:
+            raise InjectedFailure(f"Injected failure at failpoint '{point}'")
+
+    @staticmethod
+    def _parse_points(raw: str) -> set[str]:
+        return {point.strip() for point in raw.split(",") if point.strip()}
+
+    @staticmethod
+    def _parse_counts(raw: str) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for entry in raw.split(","):
+            item = entry.strip()
+            if not item or ":" not in item:
+                continue
+
+            name, value = item.split(":", 1)
+            point = name.strip()
+            if not point:
+                continue
+
+            try:
+                count = int(value)
+            except ValueError:
+                continue
+
+            if count > 0:
+                counts[point] = count
+        return counts

--- a/src/openalex_cli/filters.py
+++ b/src/openalex_cli/filters.py
@@ -109,6 +109,7 @@ def _parse_json_file(path: Path) -> list[dict]:
         raise ValueError(f"No filters found in {path}. 'filters' array is empty.")
 
     filters = []
+    seen_ids = set()
     for i, raw_filter in enumerate(raw_filters, 1):
         if not isinstance(raw_filter, dict):
             raise ValueError(f"Invalid filter at index {i} in {path}: expected object")
@@ -121,6 +122,14 @@ def _parse_json_file(path: Path) -> list[dict]:
         filter_id = raw_filter.get("id")
         if not filter_id:
             filter_id = _generate_filter_id(filter_str)
+
+        # Check for duplicate IDs
+        if filter_id in seen_ids:
+            raise ValueError(
+                f"Duplicate filter ID '{filter_id}' at index {i} in {path}. "
+                f"Each filter must have a unique 'id' field."
+            )
+        seen_ids.add(filter_id)
 
         # Auto-generate name if missing
         name = raw_filter.get("name")
@@ -172,18 +181,24 @@ def auto_convert_txt_to_json(txt_path: str | Path) -> Path:
     return json_path
 
 
-async def validate_filters(filters: list[dict], api_key: str) -> list[dict]:
+async def validate_filters(
+    filters: list[dict],
+    api_key: str,
+    progress_tracker=None,
+) -> list[dict]:
     """Validate filter strings by checking them against the OpenAlex API.
 
     Args:
         filters: List of filter configurations
         api_key: OpenAlex API key
+        progress_tracker: Optional progress tracker for logging warnings
 
     Returns:
         List of valid filters (invalid ones are logged and excluded)
     """
     client = OpenAlexAPIClient(api_key=api_key)
     valid_filters = []
+    warnings = []
 
     try:
         for filter_config in filters:
@@ -196,10 +211,20 @@ async def validate_filters(filters: list[dict], api_key: str) -> list[dict]:
                 if count is not None and count > 0:
                     valid_filters.append(filter_config)
                 else:
-                    print(f"Warning: Filter '{name}' returned no results, skipping: {filter_str}")
+                    msg = f"Filter '{name}' returned no results, skipping: {filter_str}"
+                    warnings.append(msg)
+                    if progress_tracker:
+                        progress_tracker.log_warning(msg)
             except Exception as e:
-                print(f"Warning: Filter '{name}' validation failed, skipping: {e}")
+                msg = f"Filter '{name}' validation failed, skipping: {e}"
+                warnings.append(msg)
+                if progress_tracker:
+                    progress_tracker.log_warning(msg)
     finally:
         await client.close()
+
+    # If no progress tracker, print warnings at end
+    if not progress_tracker and warnings:
+        print("\n".join(warnings))
 
     return valid_filters

--- a/src/openalex_cli/filters.py
+++ b/src/openalex_cli/filters.py
@@ -1,0 +1,205 @@
+"""Filter file parsing and management for multi-filter downloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from .api_client import OpenAlexAPIClient
+
+
+def _generate_filter_id(filter_str: str) -> str:
+    """Generate a stable 8-character hash ID from a filter string."""
+    return hashlib.sha256(filter_str.encode("utf-8")).hexdigest()[:8]
+
+
+def parse_filters_file(file_path: str | Path) -> list[dict]:
+    """Parse a filter file (.txt or .json) and return a list of filter configs.
+
+    Args:
+        file_path: Path to the filter file
+
+    Returns:
+        List of filter configurations with keys: id, name, filter
+
+    Raises:
+        ValueError: If file format is unsupported or content is invalid
+    """
+    path = Path(file_path)
+    suffix = path.suffix.lower()
+
+    if suffix == ".txt":
+        return _parse_txt_file(path)
+    elif suffix == ".json":
+        return _parse_json_file(path)
+    else:
+        raise ValueError(
+            f"Unsupported filter file format: '{suffix}'. "
+            f"Use .txt (one filter per line) or .json (structured format)."
+        )
+
+
+def _parse_txt_file(path: Path) -> list[dict]:
+    """Parse a plain text filter file.
+
+    Format:
+        # This is a comment
+        publication_year:>2020,topics.id:T123
+        # Another comment
+        publication_year:2024,type:article
+    """
+    filters = []
+    with open(path, encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            # Strip whitespace
+            line = line.strip()
+
+            # Skip empty lines and comments
+            if not line or line.startswith("#"):
+                continue
+
+            # Generate ID and name
+            filter_id = _generate_filter_id(line)
+            name = f"filter_{i:03d}"
+
+            filters.append(
+                {
+                    "id": filter_id,
+                    "name": name,
+                    "filter": line,
+                }
+            )
+
+    if not filters:
+        raise ValueError(
+            f"No valid filters found in {path}. File is empty or contains only comments."
+        )
+
+    return filters
+
+
+def _parse_json_file(path: Path) -> list[dict]:
+    """Parse a JSON filter file.
+
+    Expected format:
+    {
+        "filters": [
+            {
+                "id": "abc123",      # Optional, auto-generated if missing
+                "name": "my_filter",  # Optional, auto-generated if missing
+                "filter": "publication_year:>2020"
+            }
+        ]
+    }
+    """
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Invalid JSON format in {path}: expected object, got {type(data).__name__}"
+        )
+
+    raw_filters = data.get("filters", [])
+    if not isinstance(raw_filters, list):
+        raise ValueError(f"Invalid JSON format in {path}: 'filters' must be an array")
+
+    if not raw_filters:
+        raise ValueError(f"No filters found in {path}. 'filters' array is empty.")
+
+    filters = []
+    for i, raw_filter in enumerate(raw_filters, 1):
+        if not isinstance(raw_filter, dict):
+            raise ValueError(f"Invalid filter at index {i} in {path}: expected object")
+
+        filter_str = raw_filter.get("filter")
+        if not filter_str:
+            raise ValueError(f"Filter at index {i} in {path}: missing 'filter' field")
+
+        # Auto-generate ID if missing
+        filter_id = raw_filter.get("id")
+        if not filter_id:
+            filter_id = _generate_filter_id(filter_str)
+
+        # Auto-generate name if missing
+        name = raw_filter.get("name")
+        if not name:
+            name = f"filter_{i:03d}"
+
+        filters.append(
+            {
+                "id": filter_id,
+                "name": name,
+                "filter": filter_str,
+            }
+        )
+
+    return filters
+
+
+def auto_convert_txt_to_json(txt_path: str | Path) -> Path:
+    """Auto-convert a .txt filter file to a .json sidecar file.
+
+    The generated JSON includes metadata and auto-generated names/IDs.
+    Users can edit the JSON later to customize names.
+
+    Args:
+        txt_path: Path to the .txt filter file
+
+    Returns:
+        Path to the generated .json file
+    """
+    txt_path = Path(txt_path)
+    json_path = txt_path.with_suffix(".json")
+
+    filters = parse_filters_file(txt_path)
+
+    data = {
+        "source": txt_path.name,
+        "auto_generated": True,
+        "note": (
+            "This file was auto-generated from a .txt filter file. "
+            "You can edit 'name' fields freely. "
+            "If you edit a 'filter' field, that filter will be treated as new and progress will reset."
+        ),
+        "filters": filters,
+    }
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+    return json_path
+
+
+async def validate_filters(filters: list[dict], api_key: str) -> list[dict]:
+    """Validate filter strings by checking them against the OpenAlex API.
+
+    Args:
+        filters: List of filter configurations
+        api_key: OpenAlex API key
+
+    Returns:
+        List of valid filters (invalid ones are logged and excluded)
+    """
+    client = OpenAlexAPIClient(api_key=api_key)
+    valid_filters = []
+
+    try:
+        for filter_config in filters:
+            filter_str = filter_config["filter"]
+            name = filter_config.get("name", "unnamed")
+
+            try:
+                # Check if filter returns any results
+                count = await client.get_work_count(filter_str=filter_str)
+                if count is not None and count > 0:
+                    valid_filters.append(filter_config)
+                else:
+                    print(f"Warning: Filter '{name}' returned no results, skipping: {filter_str}")
+            except Exception as e:
+                print(f"Warning: Filter '{name}' validation failed, skipping: {e}")
+    finally:
+        await client.close()
+
+    return valid_filters

--- a/src/openalex_cli/page_tracker.py
+++ b/src/openalex_cli/page_tracker.py
@@ -154,14 +154,21 @@ class PageStateStore:
 class PageTracker:
     """Own durable state for uncommitted metadata-only pages."""
 
+    FLUSH_EVERY_RESULTS = 50
+
     def __init__(self, output_dir: str | Path, checkpoint_manager: CheckpointManager):
         self.checkpoint_manager = checkpoint_manager
         self.state_store = PageStateStore(output_dir)
+        self._manifest_cache: dict[int, PageManifest] = {}
+        self._dirty_manifests: set[int] = set()
+        self._result_updates_since_flush = 0
 
     def startup_reconcile(self) -> CommitOutcome:
-        for manifest in self.state_store.list_manifests():
+        self._reload_cache()
+        for manifest in list(self._ordered_manifests()):
             if self._manifest_is_already_committed(manifest):
                 self.state_store.delete_manifest(manifest.seq)
+                self._manifest_cache.pop(manifest.seq, None)
 
         return self._commit_ready_pages()
 
@@ -171,7 +178,7 @@ class PageTracker:
 
     def resume_cursor(self, default_cursor: str) -> str | None:
         """Return the cursor to use for fresh pagination after replay."""
-        manifests = self.state_store.list_manifests()
+        manifests = self._ordered_manifests()
         if not manifests:
             return default_cursor
         return manifests[-1].cursor_out
@@ -189,11 +196,14 @@ class PageTracker:
             work_ids=work_ids,
         )
         self.state_store.save_manifest(manifest)
+        self._manifest_cache[manifest.seq] = manifest
         return manifest
 
     def replay_pending_work(self) -> list[ReplayWorkItem]:
         replay: list[ReplayWorkItem] = []
-        for manifest in self.state_store.list_manifests():
+        for manifest in self._ordered_manifests():
+            if self._manifest_is_already_committed(manifest):
+                continue
             for work_id in manifest.pending_work_ids():
                 replay.append(ReplayWorkItem(page_seq=manifest.seq, work_id=work_id))
         return replay
@@ -221,27 +231,60 @@ class PageTracker:
             credits=credits,
             error=error,
         )
-        self.state_store.save_manifest(manifest)
+        self._dirty_manifests.add(page_seq)
+        self._result_updates_since_flush += 1
+        if self._result_updates_since_flush >= self.FLUSH_EVERY_RESULTS:
+            self.flush_dirty_manifests()
         return self._commit_ready_pages()
+
+    def flush_dirty_manifests(self) -> None:
+        """Persist all dirty manifest updates in sequence order."""
+        if not self._dirty_manifests:
+            return
+
+        for seq in sorted(self._dirty_manifests):
+            manifest = self._manifest_cache.get(seq)
+            if manifest is not None:
+                self.state_store.save_manifest(manifest)
+        self._dirty_manifests.clear()
+        self._result_updates_since_flush = 0
+
+    def flush_manifest(self, page_seq: int) -> None:
+        """Persist a single dirty manifest immediately if present."""
+        if page_seq not in self._dirty_manifests:
+            return
+
+        manifest = self._manifest_cache.get(page_seq)
+        if manifest is None:
+            return
+
+        self.state_store.save_manifest(manifest)
+        self._dirty_manifests.discard(page_seq)
+        if not self._dirty_manifests:
+            self._result_updates_since_flush = 0
 
     def _commit_ready_pages(self) -> CommitOutcome:
         committed_pages = 0
         checkpoint = self.checkpoint_manager.get()
 
-        for manifest in self.state_store.list_manifests():
+        for manifest in list(self._ordered_manifests()):
             if self._manifest_is_already_committed(manifest):
                 self.state_store.delete_manifest(manifest.seq)
+                self._manifest_cache.pop(manifest.seq, None)
                 continue
 
             if not manifest.is_terminal():
                 break
 
+            self._dirty_manifests.discard(manifest.seq)
+            self.state_store.save_manifest(manifest)
             self.checkpoint_manager.commit_page(
                 cursor=manifest.cursor_out,
                 completed_entries=manifest.completed_entries(),
                 failed_work_ids=manifest.failed_work_ids(),
             )
             self.state_store.delete_manifest(manifest.seq)
+            self._manifest_cache.pop(manifest.seq, None)
             committed_pages += 1
             checkpoint = self.checkpoint_manager.get()
 
@@ -258,7 +301,18 @@ class PageTracker:
         )
 
     def _load_manifest(self, seq: int) -> PageManifest | None:
-        for manifest in self.state_store.list_manifests():
-            if manifest.seq == seq:
-                return manifest
-        return None
+        manifest = self._manifest_cache.get(seq)
+        if manifest is not None:
+            return manifest
+
+        self._reload_cache()
+        return self._manifest_cache.get(seq)
+
+    def _ordered_manifests(self) -> list[PageManifest]:
+        if not self._manifest_cache:
+            self._reload_cache()
+        return [self._manifest_cache[seq] for seq in sorted(self._manifest_cache)]
+
+    def _reload_cache(self) -> None:
+        manifests = self.state_store.list_manifests()
+        self._manifest_cache = {manifest.seq: manifest for manifest in manifests}

--- a/src/openalex_cli/page_tracker.py
+++ b/src/openalex_cli/page_tracker.py
@@ -1,0 +1,264 @@
+"""Persisted page tracking for safe metadata-only resume."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .checkpoint import CheckpointManager
+from .state_io import atomic_write_json
+
+
+@dataclass
+class PageWorkState:
+    """Terminal state for a work admitted from a page."""
+
+    state: str = "pending"
+    file_size: int = 0
+    credits: int = 0
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "file_size": self.file_size,
+            "credits": self.credits,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PageWorkState:
+        return cls(
+            state=data.get("state", "pending"),
+            file_size=data.get("file_size", 0),
+            credits=data.get("credits", 0),
+            error=data.get("error"),
+        )
+
+
+@dataclass
+class PageManifest:
+    """Durable record of a listed page and each admitted work."""
+
+    seq: int
+    cursor_in: str
+    cursor_out: str | None
+    work_ids: list[str]
+    work_states: dict[str, PageWorkState] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for work_id in self.work_ids:
+            self.work_states.setdefault(work_id, PageWorkState())
+
+    def to_dict(self) -> dict:
+        return {
+            "seq": self.seq,
+            "cursor_in": self.cursor_in,
+            "cursor_out": self.cursor_out,
+            "work_ids": self.work_ids,
+            "work_states": {
+                work_id: state.to_dict() for work_id, state in self.work_states.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PageManifest:
+        return cls(
+            seq=data["seq"],
+            cursor_in=data.get("cursor_in", "*"),
+            cursor_out=data.get("cursor_out"),
+            work_ids=list(data.get("work_ids", [])),
+            work_states={
+                work_id: PageWorkState.from_dict(state)
+                for work_id, state in data.get("work_states", {}).items()
+            },
+        )
+
+    def is_terminal(self) -> bool:
+        return all(self.work_states[work_id].state != "pending" for work_id in self.work_ids)
+
+    def pending_work_ids(self) -> list[str]:
+        return [
+            work_id for work_id in self.work_ids if self.work_states[work_id].state == "pending"
+        ]
+
+    def completed_entries(self) -> list[tuple[str, int, int]]:
+        entries: list[tuple[str, int, int]] = []
+        for work_id in self.work_ids:
+            state = self.work_states[work_id]
+            if state.state == "completed":
+                entries.append((work_id, state.file_size, state.credits))
+        return entries
+
+    def failed_work_ids(self) -> list[str]:
+        return [work_id for work_id in self.work_ids if self.work_states[work_id].state == "failed"]
+
+
+@dataclass
+class ReplayWorkItem:
+    """Pending work reconstructed from a durable page manifest."""
+
+    page_seq: int
+    work_id: str
+
+
+@dataclass
+class CommitOutcome:
+    """Result of recording a terminal work outcome."""
+
+    committed_pages: int = 0
+    current_cursor: str | None = None
+    pages_completed: int = 0
+
+
+class PageStateStore:
+    """Durable local storage for admitted page manifests."""
+
+    DIRNAME = ".openalex-pages"
+
+    def __init__(self, output_dir: str | Path):
+        self.base_dir = Path(output_dir) / self.DIRNAME
+
+    def list_manifests(self) -> list[PageManifest]:
+        if not self.base_dir.exists():
+            return []
+
+        manifests: list[PageManifest] = []
+        for path in sorted(self.base_dir.glob("page-*.json")):
+            with open(path, encoding="utf-8") as f:
+                manifests.append(PageManifest.from_dict(json.load(f)))
+        manifests.sort(key=lambda manifest: manifest.seq)
+        return manifests
+
+    def has_manifests(self) -> bool:
+        """Return True when any persisted page manifests exist."""
+        return any(self.base_dir.glob("page-*.json")) if self.base_dir.exists() else False
+
+    def save_manifest(self, manifest: PageManifest) -> None:
+        atomic_write_json(self._manifest_path(manifest.seq), manifest.to_dict())
+
+    def delete_manifest(self, seq: int) -> None:
+        path = self._manifest_path(seq)
+        if path.exists():
+            path.unlink()
+
+    def next_seq(self) -> int:
+        manifests = self.list_manifests()
+        return (manifests[-1].seq + 1) if manifests else 1
+
+    def _manifest_path(self, seq: int) -> Path:
+        return self.base_dir / f"page-{seq:08d}.json"
+
+
+class PageTracker:
+    """Own durable state for uncommitted metadata-only pages."""
+
+    def __init__(self, output_dir: str | Path, checkpoint_manager: CheckpointManager):
+        self.checkpoint_manager = checkpoint_manager
+        self.state_store = PageStateStore(output_dir)
+
+    def startup_reconcile(self) -> CommitOutcome:
+        for manifest in self.state_store.list_manifests():
+            if self._manifest_is_already_committed(manifest):
+                self.state_store.delete_manifest(manifest.seq)
+
+        return self._commit_ready_pages()
+
+    def has_uncommitted_pages(self) -> bool:
+        """Return True when durable uncommitted page manifests remain."""
+        return self.state_store.has_manifests()
+
+    def resume_cursor(self, default_cursor: str) -> str | None:
+        """Return the cursor to use for fresh pagination after replay."""
+        manifests = self.state_store.list_manifests()
+        if not manifests:
+            return default_cursor
+        return manifests[-1].cursor_out
+
+    def register_page(
+        self,
+        cursor_in: str,
+        cursor_out: str | None,
+        work_ids: list[str],
+    ) -> PageManifest:
+        manifest = PageManifest(
+            seq=self.state_store.next_seq(),
+            cursor_in=cursor_in,
+            cursor_out=cursor_out,
+            work_ids=work_ids,
+        )
+        self.state_store.save_manifest(manifest)
+        return manifest
+
+    def replay_pending_work(self) -> list[ReplayWorkItem]:
+        replay: list[ReplayWorkItem] = []
+        for manifest in self.state_store.list_manifests():
+            for work_id in manifest.pending_work_ids():
+                replay.append(ReplayWorkItem(page_seq=manifest.seq, work_id=work_id))
+        return replay
+
+    def record_work_result(
+        self,
+        page_seq: int,
+        work_id: str,
+        success: bool,
+        file_size: int,
+        credits: int,
+        error: str | None,
+    ) -> CommitOutcome:
+        manifest = self._load_manifest(page_seq)
+        if manifest is None:
+            return CommitOutcome()
+
+        state = manifest.work_states.get(work_id)
+        if state is None or state.state != "pending":
+            return CommitOutcome()
+
+        manifest.work_states[work_id] = PageWorkState(
+            state="completed" if success else "failed",
+            file_size=file_size,
+            credits=credits,
+            error=error,
+        )
+        self.state_store.save_manifest(manifest)
+        return self._commit_ready_pages()
+
+    def _commit_ready_pages(self) -> CommitOutcome:
+        committed_pages = 0
+        checkpoint = self.checkpoint_manager.get()
+
+        for manifest in self.state_store.list_manifests():
+            if self._manifest_is_already_committed(manifest):
+                self.state_store.delete_manifest(manifest.seq)
+                continue
+
+            if not manifest.is_terminal():
+                break
+
+            self.checkpoint_manager.commit_page(
+                cursor=manifest.cursor_out,
+                completed_entries=manifest.completed_entries(),
+                failed_work_ids=manifest.failed_work_ids(),
+            )
+            self.state_store.delete_manifest(manifest.seq)
+            committed_pages += 1
+            checkpoint = self.checkpoint_manager.get()
+
+        return CommitOutcome(
+            committed_pages=committed_pages,
+            current_cursor=checkpoint.current_cursor,
+            pages_completed=checkpoint.pages_completed,
+        )
+
+    def _manifest_is_already_committed(self, manifest: PageManifest) -> bool:
+        terminal_ids = self.checkpoint_manager.terminal_work_ids()
+        return bool(manifest.work_ids) and all(
+            work_id in terminal_ids for work_id in manifest.work_ids
+        )
+
+    def _load_manifest(self, seq: int) -> PageManifest | None:
+        for manifest in self.state_store.list_manifests():
+            if manifest.seq == seq:
+                return manifest
+        return None

--- a/src/openalex_cli/progress.py
+++ b/src/openalex_cli/progress.py
@@ -7,6 +7,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from rich.console import Console
 from rich.live import Live
@@ -37,6 +38,8 @@ class ProgressStats:
     start_time: float = 0.0
     pages_completed: int = 0
     current_cursor: str | None = None
+    expected_total_works: int | None = None
+    starting_completed: int = 0
 
 
 class ProgressTracker:
@@ -164,6 +167,20 @@ class ProgressTracker:
         self.stats.current_cursor = cursor
         self._refresh_display()
 
+    def initialize_totals(
+        self,
+        starting_completed: int,
+        expected_total_works: int | None,
+    ) -> None:
+        """Initialize total progress tracking for a new or resumed run."""
+        self.stats.starting_completed = starting_completed
+        self.stats.expected_total_works = expected_total_works
+
+        if self._progress and self._task_id is not None and expected_total_works is not None:
+            self._progress.update(self._task_id, total=expected_total_works)
+
+        self._refresh_display()
+
     def log_info(self, message: str) -> None:
         """Log an info message."""
         self._logger.info(message)
@@ -186,7 +203,12 @@ class ProgressTracker:
         """Refresh the Rich display."""
         if self._live and self._progress and self._task_id is not None:
             stats = self._format_stats()
-            self._progress.update(self._task_id, stats=stats)
+            update_kwargs: dict[str, Any] = {"stats": stats}
+            if self.stats.expected_total_works is not None:
+                update_kwargs["completed"] = (
+                    self.stats.starting_completed + self.stats.total_downloaded
+                )
+            self._progress.update(self._task_id, **update_kwargs)
             self._live.update(self._make_display())
 
     def _make_display(self) -> Panel:
@@ -217,6 +239,23 @@ class ProgressTracker:
             "Pages:",
             f"{self.stats.pages_completed} completed",
         )
+
+        if self.stats.expected_total_works is not None:
+            completed = self.stats.starting_completed + self.stats.total_downloaded
+            remaining = max(self.stats.expected_total_works - completed, 0)
+            percent = (
+                completed / self.stats.expected_total_works
+                if self.stats.expected_total_works
+                else 0
+            )
+            table.add_row(
+                "Progress:",
+                f"{format_count(completed)} / {format_count(self.stats.expected_total_works)} ({percent:.1%})",
+            )
+            table.add_row(
+                "Remaining:",
+                f"{format_count(remaining)} works",
+            )
 
         # API health
         if self._rate_state:
@@ -262,6 +301,13 @@ class ProgressTracker:
         """Format stats for the progress bar."""
         elapsed = time.time() - self.stats.start_time
         files_per_sec = self.stats.total_downloaded / elapsed if elapsed > 0 else 0
+        if self.stats.expected_total_works is not None:
+            completed = self.stats.starting_completed + self.stats.total_downloaded
+            return (
+                f"{format_count(completed)} / {format_count(self.stats.expected_total_works)} • "
+                f"{format_count(self.stats.total_failed)} failed • "
+                f"{files_per_sec:.1f}/s"
+            )
         return (
             f"{format_count(self.stats.total_downloaded)} OK • "
             f"{format_count(self.stats.total_failed)} failed • "

--- a/src/openalex_cli/progress.py
+++ b/src/openalex_cli/progress.py
@@ -45,6 +45,7 @@ class ProgressStats:
     retry_attempted: int = 0
     retry_recovered: int = 0
     retry_remaining: int = 0
+    current_filter: str | None = None
 
 
 class ProgressTracker:
@@ -205,6 +206,11 @@ class ProgressTracker:
         self.stats.retry_remaining = remaining
         self._refresh_display()
 
+    def set_current_filter(self, filter_name: str | None) -> None:
+        """Set the current filter being processed (for multi-filter mode)."""
+        self.stats.current_filter = filter_name
+        self._refresh_display()
+
     def log_info(self, message: str) -> None:
         """Log an info message."""
         self._logger.info(message)
@@ -261,6 +267,11 @@ class ProgressTracker:
             "Pages:",
             f"{self.stats.pages_completed} completed",
         )
+        if self.stats.current_filter:
+            table.add_row(
+                "Current filter:",
+                f"[cyan]{self.stats.current_filter}[/cyan]",
+            )
         table.add_row(
             "Unresolved failed:",
             f"{format_count(self.stats.authoritative_unresolved_failed)} works",

--- a/src/openalex_cli/progress.py
+++ b/src/openalex_cli/progress.py
@@ -77,6 +77,9 @@ class ProgressTracker:
         self._progress: Progress | None = None
         self._task_id: TaskID | None = None
 
+        # Multi-filter task tracking
+        self._filter_tasks: dict[str, TaskID] = {}
+
     def _setup_logging(self) -> None:
         """Set up file and console logging."""
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -210,6 +213,32 @@ class ProgressTracker:
         """Set the current filter being processed (for multi-filter mode)."""
         self.stats.current_filter = filter_name
         self._refresh_display()
+
+    def add_filter_task(self, filter_name: str, total: int | None = None) -> None:
+        """Add a progress task for a specific filter (multi-filter mode)."""
+        if self.is_tty and self._progress and filter_name not in self._filter_tasks:
+            task_id = self._progress.add_task(
+                f"[cyan]{filter_name}[/cyan]",
+                total=total,
+                completed=0,
+            )
+            self._filter_tasks[filter_name] = task_id
+
+    def update_filter_progress(self, filter_name: str, completed: int) -> None:
+        """Update progress for a specific filter task."""
+        if self.is_tty and self._progress and filter_name in self._filter_tasks:
+            self._progress.update(
+                self._filter_tasks[filter_name],
+                completed=completed,
+            )
+
+    def complete_filter_task(self, filter_name: str) -> None:
+        """Mark a filter task as complete."""
+        if self.is_tty and self._progress and filter_name in self._filter_tasks:
+            self._progress.update(
+                self._filter_tasks[filter_name],
+                completed=self._progress.tasks[self._filter_tasks[filter_name]].total or 1,
+            )
 
     def log_info(self, message: str) -> None:
         """Log an info message."""

--- a/src/openalex_cli/progress.py
+++ b/src/openalex_cli/progress.py
@@ -42,6 +42,9 @@ class ProgressStats:
     starting_completed: int = 0
     authoritative_completed: int = 0
     authoritative_unresolved_failed: int = 0
+    retry_attempted: int = 0
+    retry_recovered: int = 0
+    retry_remaining: int = 0
 
 
 class ProgressTracker:
@@ -193,6 +196,13 @@ class ProgressTracker:
         self.stats.authoritative_completed = completed_count
         if unresolved_failed_count is not None:
             self.stats.authoritative_unresolved_failed = unresolved_failed_count
+        self._refresh_display()
+
+    def record_retry_summary(self, attempted: int, recovered: int, remaining: int) -> None:
+        """Record the outcome of the failed-work retry phase."""
+        self.stats.retry_attempted = attempted
+        self.stats.retry_recovered = recovered
+        self.stats.retry_remaining = remaining
         self._refresh_display()
 
     def log_info(self, message: str) -> None:
@@ -355,6 +365,13 @@ class ProgressTracker:
             f"  Duration: {elapsed:.1f}s\n"
             f"  Average speed: {format_rate(rate)}"
         )
+
+        if self.stats.retry_attempted:
+            summary += (
+                f"\n  Retry recovery: {format_count(self.stats.retry_recovered)} / "
+                f"{format_count(self.stats.retry_attempted)} succeeded"
+                f" ({format_count(self.stats.retry_remaining)} unresolved remaining)"
+            )
 
         self._logger.info(summary)
         if self.is_tty:

--- a/src/openalex_cli/progress.py
+++ b/src/openalex_cli/progress.py
@@ -40,6 +40,8 @@ class ProgressStats:
     current_cursor: str | None = None
     expected_total_works: int | None = None
     starting_completed: int = 0
+    authoritative_completed: int = 0
+    authoritative_unresolved_failed: int = 0
 
 
 class ProgressTracker:
@@ -175,10 +177,22 @@ class ProgressTracker:
         """Initialize total progress tracking for a new or resumed run."""
         self.stats.starting_completed = starting_completed
         self.stats.expected_total_works = expected_total_works
+        self.stats.authoritative_completed = starting_completed
 
         if self._progress and self._task_id is not None and expected_total_works is not None:
             self._progress.update(self._task_id, total=expected_total_works)
 
+        self._refresh_display()
+
+    def sync_checkpoint_state(
+        self,
+        completed_count: int,
+        unresolved_failed_count: int | None = None,
+    ) -> None:
+        """Sync progress display with durable checkpoint state."""
+        self.stats.authoritative_completed = completed_count
+        if unresolved_failed_count is not None:
+            self.stats.authoritative_unresolved_failed = unresolved_failed_count
         self._refresh_display()
 
     def log_info(self, message: str) -> None:
@@ -205,9 +219,7 @@ class ProgressTracker:
             stats = self._format_stats()
             update_kwargs: dict[str, Any] = {"stats": stats}
             if self.stats.expected_total_works is not None:
-                update_kwargs["completed"] = (
-                    self.stats.starting_completed + self.stats.total_downloaded
-                )
+                update_kwargs["completed"] = self.stats.authoritative_completed
             self._progress.update(self._task_id, **update_kwargs)
             self._live.update(self._make_display())
 
@@ -239,9 +251,13 @@ class ProgressTracker:
             "Pages:",
             f"{self.stats.pages_completed} completed",
         )
+        table.add_row(
+            "Unresolved failed:",
+            f"{format_count(self.stats.authoritative_unresolved_failed)} works",
+        )
 
         if self.stats.expected_total_works is not None:
-            completed = self.stats.starting_completed + self.stats.total_downloaded
+            completed = self.stats.authoritative_completed
             remaining = max(self.stats.expected_total_works - completed, 0)
             percent = (
                 completed / self.stats.expected_total_works
@@ -302,7 +318,7 @@ class ProgressTracker:
         elapsed = time.time() - self.stats.start_time
         files_per_sec = self.stats.total_downloaded / elapsed if elapsed > 0 else 0
         if self.stats.expected_total_works is not None:
-            completed = self.stats.starting_completed + self.stats.total_downloaded
+            completed = self.stats.authoritative_completed
             return (
                 f"{format_count(completed)} / {format_count(self.stats.expected_total_works)} • "
                 f"{format_count(self.stats.total_failed)} failed • "

--- a/src/openalex_cli/rate_limiter.py
+++ b/src/openalex_cli/rate_limiter.py
@@ -190,7 +190,7 @@ class AdaptiveRateLimiter:
         Returns the actual wait time in seconds.
         """
         wait_time = min(
-            self._current_backoff * (self.BACKOFF_MULTIPLIER ** self._consecutive_errors),
+            self._current_backoff * (self.BACKOFF_MULTIPLIER**self._consecutive_errors),
             self.MAX_BACKOFF,
         )
         await asyncio.sleep(wait_time)
@@ -219,6 +219,4 @@ class AdaptiveRateLimiter:
     def should_continue(self) -> bool:
         """Check if we should continue making requests."""
         # Stop if rate limit is exhausted
-        if self._rate_limit_remaining is not None and self._rate_limit_remaining <= 0:
-            return False
-        return True
+        return not (self._rate_limit_remaining is not None and self._rate_limit_remaining <= 0)

--- a/src/openalex_cli/state_io.py
+++ b/src/openalex_cli/state_io.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import time
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
+
+WINDOWS_REPLACE_RETRIES = 8
+WINDOWS_RETRY_DELAY_SECONDS = 0.05
 
 
 def atomic_write_bytes(path: Path, content: bytes) -> None:
@@ -26,7 +30,7 @@ def atomic_write_bytes(path: Path, content: bytes) -> None:
             f.flush()
             os.fsync(f.fileno())
 
-        os.replace(tmp_path, path)
+        _replace_with_retry(tmp_path, path)
     except Exception:
         with suppress(FileNotFoundError):
             os.unlink(tmp_path)
@@ -36,3 +40,22 @@ def atomic_write_bytes(path: Path, content: bytes) -> None:
 def atomic_write_json(path: Path, data: Any) -> None:
     """Atomically replace a JSON file."""
     atomic_write_bytes(path, json.dumps(data, indent=2).encode("utf-8"))
+
+
+def _replace_with_retry(tmp_path: str, path: Path) -> None:
+    """Retry os.replace for transient Windows file-lock contention."""
+    attempts = WINDOWS_REPLACE_RETRIES if os.name == "nt" else 1
+    last_error: PermissionError | None = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            os.replace(tmp_path, path)
+            return
+        except PermissionError as exc:
+            last_error = exc
+            if attempt == attempts:
+                break
+            time.sleep(WINDOWS_RETRY_DELAY_SECONDS * attempt)
+
+    if last_error is not None:
+        raise last_error

--- a/src/openalex_cli/state_io.py
+++ b/src/openalex_cli/state_io.py
@@ -1,0 +1,38 @@
+"""Helpers for durable local state writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Atomically replace a file with the provided bytes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+
+        os.replace(tmp_path, path)
+    except Exception:
+        with suppress(FileNotFoundError):
+            os.unlink(tmp_path)
+        raise
+
+
+def atomic_write_json(path: Path, data: Any) -> None:
+    """Atomically replace a JSON file."""
+    atomic_write_bytes(path, json.dumps(data, indent=2).encode("utf-8"))

--- a/src/openalex_cli/storage/__init__.py
+++ b/src/openalex_cli/storage/__init__.py
@@ -1,7 +1,13 @@
 """Storage backends for the OpenAlex content downloader."""
 
+from importlib import import_module
+
 from .base import StorageBackend
 from .local import LocalStorage
-from .s3 import S3Storage
+
+try:
+    S3Storage = import_module("openalex_cli.storage.s3").S3Storage
+except ModuleNotFoundError:  # pragma: no cover - optional dependency in local-only environments
+    S3Storage = None
 
 __all__ = ["StorageBackend", "LocalStorage", "S3Storage"]

--- a/src/openalex_cli/storage/local.py
+++ b/src/openalex_cli/storage/local.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+from ..state_io import atomic_write_bytes
 from .base import StorageBackend
 
 
@@ -37,7 +38,7 @@ class LocalStorage(StorageBackend):
 
     def _write_file(self, path: Path, content: bytes) -> None:
         """Synchronous file write."""
-        path.write_bytes(content)
+        atomic_write_bytes(path, content)
 
     async def exists(self, path: str) -> bool:
         """Check if a file exists."""

--- a/src/openalex_cli/storage/s3.py
+++ b/src/openalex_cli/storage/s3.py
@@ -3,14 +3,10 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
 
-from aiobotocore.session import get_session
+from aiobotocore.session import get_session  # type: ignore[import-untyped]
 
 from .base import StorageBackend
-
-if TYPE_CHECKING:
-    from types_aiobotocore_s3 import S3Client
 
 
 class S3Storage(StorageBackend):

--- a/src/openalex_cli/utils.py
+++ b/src/openalex_cli/utils.py
@@ -125,13 +125,14 @@ def doi_to_filename(doi: str) -> str:
     return doi.replace("/", "_").replace(":", "_")
 
 
-def format_bytes(num_bytes: int) -> str:
+def format_bytes(num_bytes: float) -> str:
     """Format bytes as human-readable string."""
+    value = float(num_bytes)
     for unit in ["B", "KB", "MB", "GB", "TB"]:
-        if abs(num_bytes) < 1024:
-            return f"{num_bytes:.1f} {unit}"
-        num_bytes /= 1024
-    return f"{num_bytes:.1f} PB"
+        if abs(value) < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} PB"
 
 
 def format_rate(bytes_per_second: float) -> str:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,55 @@
+"""Tests for API client retry behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import aiohttp
+import pytest
+
+from openalex_cli.api_client import CreditsExhaustedError, OpenAlexAPIClient
+
+
+@pytest.mark.asyncio
+async def test_get_work_metadata_with_retry_retries_429(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    async def fake_get_work_metadata(work_id: str):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=429,
+                message="Rate limited",
+            )
+        return {"id": f"https://openalex.org/{work_id}"}
+
+    async def fake_sleep(_: float):
+        return None
+
+    monkeypatch.setattr(client, "get_work_metadata", fake_get_work_metadata)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    result = await client.get_work_metadata_with_retry("W123", max_attempts=3)
+
+    assert result == {"id": "https://openalex.org/W123"}
+    assert calls["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_get_work_metadata_with_retry_does_not_retry_credits_exhausted(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    async def fake_get_work_metadata(_: str):
+        calls["count"] += 1
+        raise CreditsExhaustedError("Insufficient credits")
+
+    monkeypatch.setattr(client, "get_work_metadata", fake_get_work_metadata)
+
+    with pytest.raises(CreditsExhaustedError):
+        await client.get_work_metadata_with_retry("W123", max_attempts=3)
+
+    assert calls["count"] == 1

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,12 +1,8 @@
 """Tests for checkpoint system."""
 
-import json
 import tempfile
-from pathlib import Path
 
-import pytest
-
-from openalex_cli.checkpoint import Checkpoint, CheckpointManager, DownloadStats
+from openalex_cli.checkpoint import Checkpoint, CheckpointManager
 
 
 class TestCheckpoint:
@@ -111,3 +107,23 @@ class TestCheckpointManager:
             manager2 = CheckpointManager(tmpdir)
             loaded = manager2.load()
             assert len(loaded.completed_work_ids) == 100
+
+    def test_commit_page(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = CheckpointManager(tmpdir)
+            manager.create(filter_str="type:article", content_format="none")
+
+            manager.commit_page(
+                cursor="cursor_abc",
+                completed_entries=[("W1", 100, 0), ("W2", 200, 0)],
+                failed_work_ids=["W3"],
+            )
+
+            checkpoint = manager.get()
+            assert checkpoint.current_cursor == "cursor_abc"
+            assert checkpoint.pages_completed == 1
+            assert checkpoint.completed_work_ids == {"W1", "W2"}
+            assert checkpoint.failed_work_ids == {"W3"}
+            assert checkpoint.stats.total_downloaded == 2
+            assert checkpoint.stats.total_failed == 1
+            assert checkpoint.stats.total_bytes == 300

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -10,6 +10,7 @@ class TestCheckpoint:
         checkpoint = Checkpoint(
             filter_str="publication_year:2024",
             content_format="pdf",
+            expected_total_works=12345,
             current_cursor="abc123",
             pages_completed=5,
             completed_work_ids={"W1", "W2", "W3"},
@@ -23,6 +24,7 @@ class TestCheckpoint:
 
         assert restored.filter_str == "publication_year:2024"
         assert restored.content_format == "pdf"
+        assert restored.expected_total_works == 12345
         assert restored.current_cursor == "abc123"
         assert restored.pages_completed == 5
         assert restored.completed_work_ids == {"W1", "W2", "W3"}
@@ -40,9 +42,11 @@ class TestCheckpointManager:
             checkpoint = manager.create(
                 filter_str="type:article",
                 content_format="xml",
+                expected_total_works=999,
             )
             assert checkpoint.filter_str == "type:article"
             assert checkpoint.content_format == "xml"
+            assert checkpoint.expected_total_works == 999
 
             # Load should return same data
             manager2 = CheckpointManager(tmpdir)
@@ -50,6 +54,7 @@ class TestCheckpointManager:
             assert loaded is not None
             assert loaded.filter_str == "type:article"
             assert loaded.content_format == "xml"
+            assert loaded.expected_total_works == 999
 
     def test_mark_completed(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -140,6 +145,7 @@ class TestCheckpointManager:
             # Verify saved to disk
             manager2 = CheckpointManager(tmpdir)
             loaded = manager2.load()
+            assert loaded is not None
             assert len(loaded.completed_work_ids) == 100
 
     def test_commit_page(self):

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -73,6 +73,40 @@ class TestCheckpointManager:
             assert "W123" in manager.get().failed_work_ids
             assert manager.get().stats.total_failed == 1
 
+    def test_get_failed_work_ids_sorted(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = CheckpointManager(tmpdir)
+            manager.create()
+            manager.mark_failed("W2")
+            manager.mark_failed("W1")
+
+            assert manager.get_failed_work_ids() == ["W1", "W2"]
+
+    def test_resolve_failed_work_moves_id_to_completed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = CheckpointManager(tmpdir)
+            manager.create()
+            manager.mark_failed("W1")
+
+            manager.resolve_failed_work("W1", 100, 0)
+
+            checkpoint = manager.get()
+            assert "W1" not in checkpoint.failed_work_ids
+            assert "W1" in checkpoint.completed_work_ids
+            assert checkpoint.stats.total_downloaded == 1
+            assert checkpoint.stats.total_bytes == 100
+
+    def test_record_failed_retry_keeps_id_failed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = CheckpointManager(tmpdir)
+            manager.create()
+            manager.mark_failed("W1")
+
+            manager.record_failed_retry("W1")
+
+            checkpoint = manager.get()
+            assert "W1" in checkpoint.failed_work_ids
+
     def test_update_cursor(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = CheckpointManager(tmpdir)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 
-from openalex_cli.api_client import WorkItem
+from openalex_cli.api_client import DownloadResult, WorkItem
 from openalex_cli.downloader import DownloadConfig, DownloadOrchestrator, QueuedWork
 from openalex_cli.progress import ProgressTracker
 from openalex_cli.utils import ContentFormat, StorageType
@@ -172,3 +172,236 @@ async def test_run_commits_terminal_manifest_during_startup_reconcile(tmp_path):
 
 async def _async_noop():
     return None
+
+
+async def _drain_metadata_only_run(orchestrator: DownloadOrchestrator) -> None:
+    """Run producer, one worker, and result processor to convergence."""
+    orchestrator._work_queue = asyncio.Queue()
+    orchestrator._results_queue = asyncio.Queue()
+
+    worker = asyncio.create_task(orchestrator._download_worker(0))
+    result_processor = asyncio.create_task(orchestrator._process_results())
+
+    await orchestrator._produce_work()
+    await orchestrator._work_queue.put(None)
+    await worker
+    await orchestrator._results_queue.put(
+        DownloadResult(work_id="__DONE__", format=ContentFormat.NONE, success=True)
+    )
+    await result_processor
+
+
+def _metadata_doc(work_id: str) -> dict[str, Any]:
+    return {
+        "id": f"https://openalex.org/{work_id}",
+        "has_content": {},
+        "title": work_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_failpoint_triggers_after_page_register(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_page_register")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator._work_queue = asyncio.Queue()
+
+    async def one_page(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format, cursor
+        yield [WorkItem(work_id="W1")], "cursor-1"
+
+    orchestrator.api_client.list_works = one_page  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="after_page_register"):
+        await orchestrator._produce_work()
+
+    manifests = orchestrator.page_tracker.state_store.list_manifests()
+    assert len(manifests) == 1
+    assert manifests[0].work_ids == ["W1"]
+
+
+@pytest.mark.asyncio
+async def test_failpoint_triggers_after_page_commit(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_page_commit")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    page = orchestrator.page_tracker.register_page("*", "cursor-1", ["W1"])
+    orchestrator._results_queue = asyncio.Queue()
+    await orchestrator._results_queue.put(
+        DownloadResult(
+            work_id="W1",
+            format=ContentFormat.NONE,
+            success=True,
+            file_size=10,
+            credits_cost=0,
+            page_seq=page.seq,
+        )
+    )
+    await orchestrator._results_queue.put(
+        DownloadResult(work_id="__DONE__", format=ContentFormat.NONE, success=True)
+    )
+
+    with pytest.raises(RuntimeError, match="after_page_commit"):
+        await orchestrator._process_results()
+
+    checkpoint = orchestrator.checkpoint_manager.get()
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.completed_work_ids == {"W1"}
+    assert orchestrator.page_tracker.state_store.list_manifests() == []
+
+
+@pytest.mark.asyncio
+async def test_restart_after_page_register_replays_from_disk_and_converges(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_page_register")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+
+    first = DownloadOrchestrator(config)
+    first.checkpoint_manager.create(filter_str=None, content_format="none")
+    first._work_queue = asyncio.Queue()
+
+    async def one_page_then_stop(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        if cursor == "*":
+            yield [WorkItem(work_id="W1")], "cursor-1"
+
+    first.api_client.list_works = one_page_then_stop  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="after_page_register"):
+        await first._produce_work()
+
+    assert first.page_tracker.state_store.list_manifests()[0].work_ids == ["W1"]
+
+    monkeypatch.delenv("OPENALEX_FAILPOINTS")
+
+    second = DownloadOrchestrator(config)
+    second._setup_checkpoint()
+    fetches: list[str] = []
+    second.api_client.close = _async_noop  # type: ignore[method-assign]
+    second.storage.close = _async_noop  # type: ignore[method-assign]
+
+    async def no_new_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        assert cursor == "cursor-1"
+        if False:
+            yield [], None
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        fetches.append(work_id)
+        return _metadata_doc(work_id)
+
+    second.api_client.list_works = no_new_pages  # type: ignore[method-assign]
+    second.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+
+    await _drain_metadata_only_run(second)
+
+    checkpoint = second.checkpoint_manager.get()
+    assert fetches == ["W1"]
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.completed_work_ids == {"W1"}
+    assert second.page_tracker.state_store.list_manifests() == []
+    assert (tmp_path / "W1.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_restart_after_result_record_replays_only_remaining_work(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENALEX_FAILPOINTS", "after_result_record")
+
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+
+    first = DownloadOrchestrator(config)
+    first.checkpoint_manager.create(filter_str=None, content_format="none")
+    page = first.page_tracker.register_page("*", "cursor-1", ["W1", "W2"])
+    first._results_queue = asyncio.Queue()
+    await first._results_queue.put(
+        DownloadResult(
+            work_id="W1",
+            format=ContentFormat.NONE,
+            success=True,
+            file_size=10,
+            credits_cost=0,
+            page_seq=page.seq,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="after_result_record"):
+        await first._process_results()
+
+    manifest = first.page_tracker.state_store.list_manifests()[0]
+    assert manifest.work_states["W1"].state == "completed"
+    assert manifest.work_states["W2"].state == "pending"
+
+    monkeypatch.delenv("OPENALEX_FAILPOINTS")
+
+    second = DownloadOrchestrator(config)
+    second._setup_checkpoint()
+    fetches: list[str] = []
+    second.api_client.close = _async_noop  # type: ignore[method-assign]
+    second.storage.close = _async_noop  # type: ignore[method-assign]
+
+    async def no_new_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        assert cursor == "cursor-1"
+        if False:
+            yield [], None
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        fetches.append(work_id)
+        return _metadata_doc(work_id)
+
+    second.api_client.list_works = no_new_pages  # type: ignore[method-assign]
+    second.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+
+    await _drain_metadata_only_run(second)
+
+    checkpoint = second.checkpoint_manager.get()
+    assert fetches == ["W2"]
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.completed_work_ids == {"W1", "W2"}
+    assert second.page_tracker.state_store.list_manifests() == []
+    assert (tmp_path / "W2.json").exists()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -12,6 +12,9 @@ from openalex_cli.utils import ContentFormat, StorageType
 
 
 class _DummyProgress:
+    def __init__(self) -> None:
+        self.info_messages: list[str] = []
+
     def log_warning(self, message: str) -> None:
         self.last_warning = message
 
@@ -37,9 +40,13 @@ class _DummyProgress:
 
     def log_info(self, message: str) -> None:
         self.last_info = message
+        self.info_messages.append(message)
 
     def log_error(self, message: str) -> None:
         self.last_error = message
+
+    def record_retry_summary(self, attempted: int, recovered: int, remaining: int) -> None:
+        self.retry_summary = (attempted, recovered, remaining)
 
 
 @pytest.mark.asyncio
@@ -541,6 +548,34 @@ async def test_retry_failed_success_resolves_failed_work(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_retry_failed_records_retry_summary(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        retry_failed=True,
+        retry_workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    dummy = _DummyProgress()
+    orchestrator.progress_tracker = cast(ProgressTracker, dummy)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.checkpoint_manager.mark_failed("W1")
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        return _metadata_doc(work_id)
+
+    orchestrator.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+    orchestrator.api_client.close = _async_noop  # type: ignore[method-assign]
+    orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
+
+    await orchestrator._run_failed_retry_phase()
+
+    assert dummy.retry_summary == (1, 1, 0)
+
+
+@pytest.mark.asyncio
 async def test_retry_failed_failure_leaves_id_failed(tmp_path):
     config = DownloadConfig(
         api_key="test-key",
@@ -731,8 +766,8 @@ async def test_setup_checkpoint_resume_log_uses_unresolved_failed_count(tmp_path
             workers=1,
         )
     )
-    progress = cast(ProgressTracker, _DummyProgress())
-    orchestrator.progress_tracker = progress
+    dummy = _DummyProgress()
+    orchestrator.progress_tracker = cast(ProgressTracker, dummy)
 
     checkpoint = orchestrator.checkpoint_manager.create(
         filter_str="publication_year:2024",
@@ -748,9 +783,69 @@ async def test_setup_checkpoint_resume_log_uses_unresolved_failed_count(tmp_path
 
     assert loaded is not None
     assert (
-        progress.last_info
+        dummy.last_info
         == "Resuming from checkpoint: 2 completed, 0 unresolved failed of 456 expected"
     )
+
+
+@pytest.mark.asyncio
+async def test_run_exits_early_when_checkpoint_is_already_complete(tmp_path):
+    existing = DownloadOrchestrator(
+        DownloadConfig(
+            api_key="test-key",
+            output_path=str(tmp_path),
+            storage_type=StorageType.LOCAL,
+            content_format=ContentFormat.NONE,
+            filter_str="publication_year:2024",
+            workers=1,
+        )
+    )
+    checkpoint = existing.checkpoint_manager.create(
+        filter_str="publication_year:2024",
+        content_format="none",
+        expected_total_works=2,
+    )
+    checkpoint.completed_work_ids = {"W1", "W2"}
+    existing.checkpoint_manager.force_save()
+
+    orchestrator = DownloadOrchestrator(
+        DownloadConfig(
+            api_key="test-key",
+            output_path=str(tmp_path),
+            storage_type=StorageType.LOCAL,
+            content_format=ContentFormat.NONE,
+            filter_str="publication_year:2024",
+            workers=1,
+        )
+    )
+    dummy = _DummyProgress()
+    orchestrator.api_client.close = _async_noop  # type: ignore[method-assign]
+    orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
+
+    async def fail_list_works(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("list_works should not run when checkpoint is already complete")
+        yield
+
+    orchestrator.api_client.list_works = fail_list_works  # type: ignore[method-assign]
+
+    await orchestrator.run(progress_tracker=cast(ProgressTracker, dummy))
+
+    assert dummy.last_totals == (2, 2)
+    assert dummy.last_sync == (2, 0)
+    assert (
+        dummy.last_info == "Nothing left to download; checkpoint already covers all expected works."
+    )
+
+
+def test_progress_tracker_summary_includes_retry_recovery(tmp_path, caplog):
+    tracker = ProgressTracker(output_dir=tmp_path, quiet=True, verbose=False)
+    tracker.record_retry_summary(attempted=571, recovered=571, remaining=0)
+
+    with caplog.at_level("INFO", logger="openalex-content"):
+        tracker.stop()
+
+    assert "Retry recovery: 571 / 571 succeeded (0 unresolved remaining)" in caplog.text
 
 
 def test_progress_tracker_initializes_known_total(tmp_path):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,52 @@
+"""Tests for downloader metadata failure handling."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from openalex_cli.api_client import DownloadResult, WorkItem
+from openalex_cli.downloader import DownloadConfig, DownloadOrchestrator
+from openalex_cli.utils import ContentFormat
+
+
+class DummyCheckpointManager:
+    def is_completed(self, work_id: str) -> bool:
+        return False
+
+
+class DummyStorage:
+    async def save(self, *_args, **_kwargs):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_download_worker_reports_failure_when_metadata_fetch_fails(monkeypatch):
+    config = DownloadConfig(api_key="test", output_path=".", workers=1)
+    orchestrator = DownloadOrchestrator(config)
+
+    async def fake_get_work_metadata_with_retry(_work_id: str):
+        raise Exception("Rate limited")
+
+    monkeypatch.setattr(
+        orchestrator.api_client,
+        "get_work_metadata_with_retry",
+        fake_get_work_metadata_with_retry,
+    )
+
+    orchestrator.storage = DummyStorage()
+    orchestrator.checkpoint_manager = DummyCheckpointManager()
+    orchestrator._work_queue = asyncio.Queue()
+    orchestrator._results_queue = asyncio.Queue()
+    await orchestrator._work_queue.put(WorkItem(work_id="W123"))
+    await orchestrator._work_queue.put(None)
+
+    await orchestrator._download_worker(worker_id=0)
+
+    result = await orchestrator._results_queue.get()
+    assert isinstance(result, DownloadResult)
+    assert result.work_id == "W123"
+    assert result.success is False
+    assert result.format == ContentFormat.NONE
+    assert "Failed to fetch metadata" in (result.error or "")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,174 @@
+"""Tests for downloader orchestration safety boundaries."""
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from openalex_cli.api_client import WorkItem
+from openalex_cli.downloader import DownloadConfig, DownloadOrchestrator, QueuedWork
+from openalex_cli.progress import ProgressTracker
+from openalex_cli.utils import ContentFormat, StorageType
+
+
+class _DummyProgress:
+    def log_warning(self, message: str) -> None:
+        self.last_warning = message
+
+    def update_pagination(self, pages: int, cursor: str | None) -> None:
+        self.last_pagination = (pages, cursor)
+
+    def update_download(self, **kwargs) -> None:
+        self.last_download = kwargs
+
+    def log_info(self, message: str) -> None:
+        self.last_info = message
+
+    def log_error(self, message: str) -> None:
+        self.last_error = message
+
+
+@pytest.mark.asyncio
+async def test_metadata_failure_records_failed_result(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+    orchestrator._work_queue = asyncio.Queue()
+    orchestrator._results_queue = asyncio.Queue()
+
+    async def failing_metadata(work_id: str) -> dict[str, Any]:
+        del work_id
+        raise RuntimeError("metadata fetch failed")
+
+    orchestrator.api_client.get_work_metadata = failing_metadata  # type: ignore[method-assign]
+
+    await orchestrator._work_queue.put(QueuedWork(work=WorkItem(work_id="W1"), page_seq=7))
+    await orchestrator._work_queue.put(None)
+
+    await orchestrator._download_worker(0)
+
+    result = await orchestrator._results_queue.get()
+    assert result.work_id == "W1"
+    assert result.success is False
+    assert result.page_seq == 7
+    assert result.error is not None
+    assert "metadata fetch failed" in result.error
+
+
+@pytest.mark.asyncio
+async def test_producer_replays_pending_page_before_pagination(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    page = orchestrator.page_tracker.register_page("*", "cursor-1", ["W1", "W2"])
+    orchestrator._work_queue = asyncio.Queue()
+
+    async def empty_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format, cursor
+        if False:
+            yield [], None
+
+    orchestrator.api_client.list_works = empty_pages  # type: ignore[method-assign]
+
+    await orchestrator._produce_work()
+
+    queued = []
+    while not orchestrator._work_queue.empty():
+        item = await orchestrator._work_queue.get()
+        assert item is not None
+        queued.append((item.page_seq, item.work.work_id))
+
+    assert queued == [(page.seq, "W1"), (page.seq, "W2")]
+
+
+@pytest.mark.asyncio
+async def test_producer_resumes_fresh_pagination_after_highest_uncommitted_cursor(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.page_tracker.register_page("*", "cursor-1", ["W1"])
+    orchestrator.page_tracker.register_page("cursor-1", "cursor-2", ["W2"])
+    orchestrator._work_queue = asyncio.Queue()
+
+    seen_cursors = []
+
+    async def empty_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format
+        seen_cursors.append(cursor)
+        if False:
+            yield [], None
+
+    orchestrator.api_client.list_works = empty_pages  # type: ignore[method-assign]
+
+    await orchestrator._produce_work()
+
+    assert seen_cursors == ["cursor-2"]
+
+
+@pytest.mark.asyncio
+async def test_run_commits_terminal_manifest_during_startup_reconcile(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.page_tracker.register_page("*", "cursor-1", ["W1"])
+    manifest = orchestrator.page_tracker.state_store.list_manifests()[0]
+    manifest.work_states["W1"].state = "completed"
+    manifest.work_states["W1"].file_size = 10
+    orchestrator.page_tracker.state_store.save_manifest(manifest)
+
+    async def empty_pages(
+        filter_str: str | None = None,
+        content_format: ContentFormat = ContentFormat.NONE,
+        cursor: str = "*",
+    ):
+        del filter_str, content_format, cursor
+        if False:
+            yield [], None
+
+    orchestrator.api_client.list_works = empty_pages  # type: ignore[method-assign]
+    orchestrator.api_client.close = _async_noop  # type: ignore[method-assign]
+    orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
+
+    await orchestrator.run(orchestrator.progress_tracker)
+
+    checkpoint = orchestrator.checkpoint_manager.get()
+    assert checkpoint.current_cursor == "cursor-1"
+    assert checkpoint.pages_completed == 1
+    assert checkpoint.completed_work_ids == {"W1"}
+
+
+async def _async_noop():
+    return None

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -409,3 +409,143 @@ async def test_restart_after_result_record_replays_only_remaining_work(tmp_path,
     assert checkpoint.completed_work_ids == {"W1", "W2"}
     assert second.page_tracker.state_store.list_manifests() == []
     assert (tmp_path / "W2.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_run_failed_retry_phase_skips_when_no_failed_ids(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        retry_failed=True,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+
+    called = False
+
+    async def fake_run_direct_work_id_phase(work_ids, workers):
+        nonlocal called
+        del work_ids, workers
+        called = True
+
+    orchestrator._run_direct_work_id_phase = fake_run_direct_work_id_phase  # type: ignore[method-assign]
+
+    await orchestrator._run_failed_retry_phase()
+
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_run_failed_retry_phase_uses_retry_workers(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        retry_failed=True,
+        retry_workers=10,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.checkpoint_manager.mark_failed("W1")
+
+    seen = {}
+
+    async def fake_run_direct_work_id_phase(work_ids, workers):
+        seen["work_ids"] = work_ids
+        seen["workers"] = workers
+
+    orchestrator._run_direct_work_id_phase = fake_run_direct_work_id_phase  # type: ignore[method-assign]
+
+    await orchestrator._run_failed_retry_phase()
+
+    assert seen["work_ids"] == ["W1"]
+    assert seen["workers"] == 10
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_success_resolves_failed_work(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        retry_failed=True,
+        retry_workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.checkpoint_manager.mark_failed("W1")
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        return _metadata_doc(work_id)
+
+    orchestrator.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+    orchestrator.api_client.close = _async_noop  # type: ignore[method-assign]
+    orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
+
+    await orchestrator._run_failed_retry_phase()
+
+    checkpoint = orchestrator.checkpoint_manager.get()
+    assert "W1" not in checkpoint.failed_work_ids
+    assert "W1" in checkpoint.completed_work_ids
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_failure_leaves_id_failed(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        retry_failed=True,
+        retry_workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.checkpoint_manager.mark_failed("W1")
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        del work_id
+        raise RuntimeError("still broken")
+
+    orchestrator.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+    orchestrator.api_client.close = _async_noop  # type: ignore[method-assign]
+    orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
+
+    await orchestrator._run_failed_retry_phase()
+
+    checkpoint = orchestrator.checkpoint_manager.get()
+    assert "W1" in checkpoint.failed_work_ids
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_does_not_invoke_page_tracker(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        retry_failed=True,
+        retry_workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    orchestrator.checkpoint_manager.mark_failed("W1")
+
+    def explode(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("page tracker should not be used in retry-failed mode")
+
+    orchestrator.page_tracker.register_page = explode  # type: ignore[method-assign]
+
+    async def fetch_metadata(work_id: str) -> dict[str, Any]:
+        return _metadata_doc(work_id)
+
+    orchestrator.api_client.get_work_metadata = fetch_metadata  # type: ignore[method-assign]
+    orchestrator.api_client.close = _async_noop  # type: ignore[method-assign]
+    orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
+
+    await orchestrator._run_failed_retry_phase()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -15,6 +15,13 @@ class _DummyProgress:
     def log_warning(self, message: str) -> None:
         self.last_warning = message
 
+    def initialize_totals(
+        self,
+        starting_completed: int,
+        expected_total_works: int | None,
+    ) -> None:
+        self.last_totals = (starting_completed, expected_total_works)
+
     def update_pagination(self, pages: int, cursor: str | None) -> None:
         self.last_pagination = (pages, cursor)
 
@@ -306,7 +313,7 @@ async def test_restart_after_page_register_replays_from_disk_and_converges(tmp_p
     monkeypatch.delenv("OPENALEX_FAILPOINTS")
 
     second = DownloadOrchestrator(config)
-    second._setup_checkpoint()
+    await second._setup_checkpoint()
     fetches: list[str] = []
     second.api_client.close = _async_noop  # type: ignore[method-assign]
     second.storage.close = _async_noop  # type: ignore[method-assign]
@@ -379,7 +386,7 @@ async def test_restart_after_result_record_replays_only_remaining_work(tmp_path,
     monkeypatch.delenv("OPENALEX_FAILPOINTS")
 
     second = DownloadOrchestrator(config)
-    second._setup_checkpoint()
+    await second._setup_checkpoint()
     fetches: list[str] = []
     second.api_client.close = _async_noop  # type: ignore[method-assign]
     second.storage.close = _async_noop  # type: ignore[method-assign]
@@ -549,3 +556,135 @@ async def test_retry_failed_does_not_invoke_page_tracker(tmp_path):
     orchestrator.storage.close = _async_noop  # type: ignore[method-assign]
 
     await orchestrator._run_failed_retry_phase()
+
+
+@pytest.mark.asyncio
+async def test_setup_checkpoint_prefetches_total_count_for_new_filter_run(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        filter_str="publication_year:2024",
+        workers=1,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+
+    calls: list[str | None] = []
+
+    async def fake_get_work_count(
+        filter_str: str | None = None, content_format: ContentFormat = ContentFormat.NONE
+    ) -> int:
+        calls.append(filter_str)
+        assert content_format == ContentFormat.NONE
+        return 321
+
+    orchestrator.api_client.get_work_count = fake_get_work_count  # type: ignore[method-assign]
+
+    checkpoint = await orchestrator._setup_checkpoint()
+
+    assert checkpoint is not None
+    assert checkpoint.expected_total_works == 321
+    assert calls == ["publication_year:2024"]
+
+
+@pytest.mark.asyncio
+async def test_setup_checkpoint_reuses_stored_total_on_resume(tmp_path):
+    manager = DownloadOrchestrator(
+        DownloadConfig(
+            api_key="test-key",
+            output_path=str(tmp_path),
+            storage_type=StorageType.LOCAL,
+            content_format=ContentFormat.NONE,
+            filter_str="publication_year:2024",
+            workers=1,
+        )
+    )
+    manager.checkpoint_manager.create(
+        filter_str="publication_year:2024",
+        content_format="none",
+        expected_total_works=456,
+    )
+
+    orchestrator = DownloadOrchestrator(
+        DownloadConfig(
+            api_key="test-key",
+            output_path=str(tmp_path),
+            storage_type=StorageType.LOCAL,
+            content_format=ContentFormat.NONE,
+            filter_str="publication_year:2024",
+            workers=1,
+        )
+    )
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+
+    async def fail_get_work_count(*args, **kwargs) -> int:
+        del args, kwargs
+        raise AssertionError("count preflight should not run on resume")
+
+    orchestrator.api_client.get_work_count = fail_get_work_count  # type: ignore[method-assign]
+
+    checkpoint = await orchestrator._setup_checkpoint()
+
+    assert checkpoint is not None
+    assert checkpoint.expected_total_works == 456
+
+
+@pytest.mark.asyncio
+async def test_setup_checkpoint_backfills_missing_total_on_resume(tmp_path):
+    existing = DownloadOrchestrator(
+        DownloadConfig(
+            api_key="test-key",
+            output_path=str(tmp_path),
+            storage_type=StorageType.LOCAL,
+            content_format=ContentFormat.NONE,
+            filter_str="publication_year:2024",
+            workers=1,
+        )
+    )
+    existing.checkpoint_manager.create(
+        filter_str="publication_year:2024",
+        content_format="none",
+        expected_total_works=None,
+    )
+
+    orchestrator = DownloadOrchestrator(
+        DownloadConfig(
+            api_key="test-key",
+            output_path=str(tmp_path),
+            storage_type=StorageType.LOCAL,
+            content_format=ContentFormat.NONE,
+            filter_str="publication_year:2024",
+            workers=1,
+        )
+    )
+    orchestrator.progress_tracker = cast(ProgressTracker, _DummyProgress())
+
+    calls: list[str | None] = []
+
+    async def fake_get_work_count(
+        filter_str: str | None = None, content_format: ContentFormat = ContentFormat.NONE
+    ) -> int:
+        calls.append(filter_str)
+        assert content_format == ContentFormat.NONE
+        return 654
+
+    orchestrator.api_client.get_work_count = fake_get_work_count  # type: ignore[method-assign]
+
+    checkpoint = await orchestrator._setup_checkpoint()
+
+    assert checkpoint is not None
+    assert checkpoint.expected_total_works == 654
+    assert calls == ["publication_year:2024"]
+
+
+def test_progress_tracker_initializes_known_total(tmp_path):
+    tracker = ProgressTracker(output_dir=tmp_path, quiet=True, verbose=False)
+
+    tracker.initialize_totals(starting_completed=100, expected_total_works=250)
+    tracker.update_download("W1", success=True, file_size=100)
+
+    assert tracker.stats.starting_completed == 100
+    assert tracker.stats.expected_total_works == 250
+    assert "101 / 250" in tracker._format_stats()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -368,9 +368,13 @@ async def test_restart_after_result_record_replays_only_remaining_work(tmp_path,
     with pytest.raises(RuntimeError, match="after_result_record"):
         await first._process_results()
 
-    manifest = first.page_tracker.state_store.list_manifests()[0]
-    assert manifest.work_states["W1"].state == "completed"
-    assert manifest.work_states["W2"].state == "pending"
+    cached_manifest = first.page_tracker._load_manifest(page.seq)
+    assert cached_manifest is not None
+    assert cached_manifest.work_states["W1"].state == "completed"
+    assert cached_manifest.work_states["W2"].state == "pending"
+
+    persisted_manifest = first.page_tracker.state_store.list_manifests()[0]
+    assert persisted_manifest.work_states["W1"].state == "completed"
 
     monkeypatch.delenv("OPENALEX_FAILPOINTS")
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -22,6 +22,13 @@ class _DummyProgress:
     ) -> None:
         self.last_totals = (starting_completed, expected_total_works)
 
+    def sync_checkpoint_state(
+        self,
+        completed_count: int,
+        unresolved_failed_count: int | None = None,
+    ) -> None:
+        self.last_sync = (completed_count, unresolved_failed_count)
+
     def update_pagination(self, pages: int, cursor: str | None) -> None:
         self.last_pagination = (pages, cursor)
 
@@ -459,10 +466,12 @@ async def test_run_failed_retry_phase_uses_retry_workers(tmp_path):
     orchestrator.checkpoint_manager.mark_failed("W1")
 
     seen = {}
+    original_rate_limiter = orchestrator.rate_limiter
 
     async def fake_run_direct_work_id_phase(work_ids, workers):
         seen["work_ids"] = work_ids
         seen["workers"] = workers
+        seen["limiter_max"] = orchestrator.rate_limiter.max_workers
 
     orchestrator._run_direct_work_id_phase = fake_run_direct_work_id_phase  # type: ignore[method-assign]
 
@@ -470,6 +479,37 @@ async def test_run_failed_retry_phase_uses_retry_workers(tmp_path):
 
     assert seen["work_ids"] == ["W1"]
     assert seen["workers"] == 10
+    assert seen["limiter_max"] == 10
+    assert orchestrator.rate_limiter is original_rate_limiter
+
+
+@pytest.mark.asyncio
+async def test_run_failed_retry_phase_skips_when_only_historical_failures_exist(tmp_path):
+    config = DownloadConfig(
+        api_key="test-key",
+        output_path=str(tmp_path),
+        storage_type=StorageType.LOCAL,
+        content_format=ContentFormat.NONE,
+        retry_failed=True,
+    )
+    orchestrator = DownloadOrchestrator(config)
+    checkpoint = orchestrator.checkpoint_manager.create(filter_str=None, content_format="none")
+    checkpoint.stats.total_failed = 558
+    checkpoint.failed_work_ids.clear()
+    orchestrator.checkpoint_manager.force_save()
+
+    called = False
+
+    async def fake_run_direct_work_id_phase(work_ids, workers):
+        nonlocal called
+        del work_ids, workers
+        called = True
+
+    orchestrator._run_direct_work_id_phase = fake_run_direct_work_id_phase  # type: ignore[method-assign]
+
+    await orchestrator._run_failed_retry_phase()
+
+    assert called is False
 
 
 @pytest.mark.asyncio
@@ -679,6 +719,40 @@ async def test_setup_checkpoint_backfills_missing_total_on_resume(tmp_path):
     assert calls == ["publication_year:2024"]
 
 
+@pytest.mark.asyncio
+async def test_setup_checkpoint_resume_log_uses_unresolved_failed_count(tmp_path):
+    orchestrator = DownloadOrchestrator(
+        DownloadConfig(
+            api_key="test-key",
+            output_path=str(tmp_path),
+            storage_type=StorageType.LOCAL,
+            content_format=ContentFormat.NONE,
+            filter_str="publication_year:2024",
+            workers=1,
+        )
+    )
+    progress = cast(ProgressTracker, _DummyProgress())
+    orchestrator.progress_tracker = progress
+
+    checkpoint = orchestrator.checkpoint_manager.create(
+        filter_str="publication_year:2024",
+        content_format="none",
+        expected_total_works=456,
+    )
+    checkpoint.completed_work_ids = {"W1", "W2"}
+    checkpoint.failed_work_ids.clear()
+    checkpoint.stats.total_failed = 558
+    orchestrator.checkpoint_manager.force_save()
+
+    loaded = await orchestrator._setup_checkpoint()
+
+    assert loaded is not None
+    assert (
+        progress.last_info
+        == "Resuming from checkpoint: 2 completed, 0 unresolved failed of 456 expected"
+    )
+
+
 def test_progress_tracker_initializes_known_total(tmp_path):
     tracker = ProgressTracker(output_dir=tmp_path, quiet=True, verbose=False)
 
@@ -687,4 +761,15 @@ def test_progress_tracker_initializes_known_total(tmp_path):
 
     assert tracker.stats.starting_completed == 100
     assert tracker.stats.expected_total_works == 250
-    assert "101 / 250" in tracker._format_stats()
+    assert "100 / 250" in tracker._format_stats()
+
+
+def test_progress_tracker_sync_uses_checkpoint_completed_count(tmp_path):
+    tracker = ProgressTracker(output_dir=tmp_path, quiet=True, verbose=False)
+
+    tracker.initialize_totals(starting_completed=100, expected_total_works=250)
+    tracker.sync_checkpoint_state(completed_count=150, unresolved_failed_count=3)
+
+    assert tracker.stats.authoritative_completed == 150
+    assert tracker.stats.authoritative_unresolved_failed == 3
+    assert "150 / 250" in tracker._format_stats()

--- a/tests/test_list_retry.py
+++ b/tests/test_list_retry.py
@@ -67,7 +67,10 @@ async def test_list_works_retries_429(monkeypatch):
     async def fake_sleep(_: float):
         return None
 
-    monkeypatch.setattr(client, "_get_session", lambda: FakeSession())
+    async def fake_get_session():
+        return FakeSession()
+
+    monkeypatch.setattr(client, "_get_session", fake_get_session)
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
     pages = []
@@ -120,7 +123,10 @@ async def test_list_works_raises_credits_exhausted_without_retry(monkeypatch):
             calls["count"] += 1
             return FakeResponse()
 
-    monkeypatch.setattr(client, "_get_session", lambda: FakeSession())
+    async def fake_get_session():
+        return FakeSession()
+
+    monkeypatch.setattr(client, "_get_session", fake_get_session)
 
     with pytest.raises(CreditsExhaustedError):
         async for _works, _cursor in client.list_works(

--- a/tests/test_list_retry.py
+++ b/tests/test_list_retry.py
@@ -1,0 +1,135 @@
+"""Tests for paginated list retry behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import aiohttp
+import pytest
+
+from openalex_cli.api_client import CreditsExhaustedError, OpenAlexAPIClient
+from openalex_cli.utils import ContentFormat
+
+
+@pytest.mark.asyncio
+async def test_list_works_retries_429(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self, status: int, payload: dict, headers: dict[str, str] | None = None):
+            self.status = status
+            self._payload = payload
+            self.headers = headers or {}
+            self.request_info = None
+            self.history = ()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            if self.status >= 400:
+                raise aiohttp.ClientResponseError(
+                    self.request_info,
+                    self.history,
+                    status=self.status,
+                    message="request failed",
+                )
+
+        async def json(self):
+            return self._payload
+
+    class FakeSession:
+        def get(self, url, params=None):
+            calls["count"] += 1
+            if calls["count"] < 3:
+                return FakeResponse(
+                    429,
+                    {},
+                    {"X-RateLimit-Remaining": "10", "X-RateLimit-Credits-Required": "1"},
+                )
+            return FakeResponse(
+                200,
+                {
+                    "results": [
+                        {
+                            "id": "https://openalex.org/W123",
+                            "has_content": {"pdf": False, "grobid_xml": False},
+                        }
+                    ],
+                    "meta": {"next_cursor": None},
+                },
+            )
+
+    async def fake_sleep(_: float):
+        return None
+
+    monkeypatch.setattr(client, "_get_session", lambda: FakeSession())
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    pages = []
+    async for works, next_cursor in client.list_works(
+        filter_str="publication_year:>2020",
+        content_format=ContentFormat.NONE,
+        cursor="*",
+        max_attempts=3,
+        base_delay_seconds=0.01,
+    ):
+        pages.append((works, next_cursor))
+
+    assert calls["count"] == 3
+    assert len(pages) == 1
+    works, next_cursor = pages[0]
+    assert len(works) == 1
+    assert works[0].work_id == "W123"
+    assert next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_list_works_raises_credits_exhausted_without_retry(monkeypatch):
+    client = OpenAlexAPIClient(api_key="test")
+    calls = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self):
+            self.status = 429
+            self.headers = {
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Credits-Required": "1",
+            }
+            self.request_info = None
+            self.history = ()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        async def json(self):
+            return {}
+
+    class FakeSession:
+        def get(self, url, params=None):
+            calls["count"] += 1
+            return FakeResponse()
+
+    monkeypatch.setattr(client, "_get_session", lambda: FakeSession())
+
+    with pytest.raises(CreditsExhaustedError):
+        async for _works, _cursor in client.list_works(
+            filter_str="publication_year:>2020",
+            content_format=ContentFormat.NONE,
+            cursor="*",
+            max_attempts=3,
+            base_delay_seconds=0.01,
+        ):
+            pass
+
+    assert calls["count"] == 1

--- a/tests/test_multi_filter.py
+++ b/tests/test_multi_filter.py
@@ -6,9 +6,8 @@ import json
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from openalex_cli.checkpoint import Checkpoint, CheckpointManager, FilterCheckpoint
+from openalex_cli.downloader import MultiFilterOrchestrator
 
 
 class TestMultiFilterCheckpoint:
@@ -185,8 +184,6 @@ class TestMultiFilterOrchestrator:
 
     def test_orchestrator_init(self):
         """MultiFilterOrchestrator should initialize with filter list."""
-        from openalex_cli.downloader import MultiFilterOrchestrator
-
         orchestrator = MultiFilterOrchestrator(
             api_key="test_key",
             output_path="/tmp/test",
@@ -201,9 +198,6 @@ class TestMultiFilterOrchestrator:
 
     def test_orchestrator_skip_complete_filter(self):
         """Orchestrator should skip filters marked as complete."""
-        from openalex_cli.downloader import MultiFilterOrchestrator
-        from openalex_cli.checkpoint import CheckpointManager
-
         with tempfile.TemporaryDirectory() as tmpdir:
             # Pre-create checkpoint with completed filter
             manager = CheckpointManager(tmpdir)

--- a/tests/test_multi_filter.py
+++ b/tests/test_multi_filter.py
@@ -1,0 +1,245 @@
+"""Tests for multi-filter download functionality."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from openalex_cli.checkpoint import Checkpoint, CheckpointManager, FilterCheckpoint
+
+
+class TestMultiFilterCheckpoint:
+    """Test multi-filter checkpoint schema."""
+
+    def test_single_mode_backward_compatibility(self):
+        """Old checkpoints without 'mode' field should load as single mode."""
+        checkpoint = Checkpoint.from_dict(
+            {
+                "filter_str": "publication_year:>2020",
+                "content_format": "none",
+                "completed_work_ids": ["W123", "W456"],
+                "failed_work_ids": ["W789"],
+                "stats": {"total_downloaded": 2, "total_failed": 1},
+            }
+        )
+
+        assert checkpoint.mode == "single"
+        assert checkpoint.filter_str == "publication_year:>2020"
+        assert checkpoint.completed_work_ids == {"W123", "W456"}
+        assert checkpoint.failed_work_ids == {"W789"}
+        assert checkpoint.filters == []
+
+    def test_multi_mode_checkpoint(self):
+        """Multi-filter checkpoint should parse filters array."""
+        checkpoint = Checkpoint.from_dict(
+            {
+                "mode": "multi",
+                "content_format": "none",
+                "completed_work_ids": ["W100"],
+                "filters": [
+                    {
+                        "id": "abc123",
+                        "name": "filter_001",
+                        "filter_str": "publication_year:>2020",
+                        "completed_work_ids": ["W100", "W200"],
+                        "failed_work_ids": [],
+                        "status": "active",
+                        "stats": {"total_downloaded": 2},
+                    }
+                ],
+                "stats": {"total_downloaded": 1},
+            }
+        )
+
+        assert checkpoint.mode == "multi"
+        assert len(checkpoint.filters) == 1
+        assert checkpoint.filters[0].id == "abc123"
+        assert checkpoint.filters[0].name == "filter_001"
+        assert checkpoint.filters[0].filter_str == "publication_year:>2020"
+        assert checkpoint.filters[0].completed_work_ids == {"W100", "W200"}
+        assert checkpoint.filters[0].status == "active"
+
+    def test_single_mode_save_backward_compatible(self):
+        """Single-mode checkpoints should save without 'mode' field."""
+        checkpoint = Checkpoint(
+            mode="single",
+            filter_str="publication_year:>2020",
+            completed_work_ids={"W123"},
+        )
+        data = checkpoint.to_dict()
+
+        assert "mode" not in data
+        assert data["filter_str"] == "publication_year:>2020"
+        assert "filters" not in data
+
+    def test_multi_mode_save_includes_filters(self):
+        """Multi-mode checkpoints should save filters array."""
+        checkpoint = Checkpoint(
+            mode="multi",
+            filters=[
+                FilterCheckpoint(
+                    id="abc123",
+                    name="filter_001",
+                    filter_str="publication_year:>2020",
+                    status="complete",
+                )
+            ],
+        )
+        data = checkpoint.to_dict()
+
+        assert data["mode"] == "multi"
+        assert "filters" in data
+        assert len(data["filters"]) == 1
+        assert data["filters"][0]["id"] == "abc123"
+        assert data["filters"][0]["status"] == "complete"
+
+    def test_filter_checkpoint_round_trip(self):
+        """FilterCheckpoint should survive round-trip serialization."""
+        original = FilterCheckpoint(
+            id="hash123",
+            name="test_filter",
+            filter_str="publication_year:2024",
+            expected_total_works=100,
+            completed_work_ids={"W1", "W2"},
+            failed_work_ids={"W3"},
+            status="stalled",
+        )
+
+        data = original.to_dict()
+        restored = FilterCheckpoint.from_dict(data)
+
+        assert restored.id == original.id
+        assert restored.name == original.name
+        assert restored.filter_str == original.filter_str
+        assert restored.expected_total_works == original.expected_total_works
+        assert restored.completed_work_ids == original.completed_work_ids
+        assert restored.failed_work_ids == original.failed_work_ids
+        assert restored.status == original.status
+
+
+class TestCheckpointManagerMultiFilter:
+    """Test CheckpointManager with multi-filter checkpoints."""
+
+    def test_save_and_load_multi_filter(self):
+        """CheckpointManager should save/load multi-filter checkpoints."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = CheckpointManager(tmpdir)
+            checkpoint = manager.create()
+            checkpoint.mode = "multi"
+            checkpoint.filters = [
+                FilterCheckpoint(
+                    id="f1",
+                    name="filter_1",
+                    filter_str="year:2024",
+                    status="active",
+                )
+            ]
+            manager.force_save()
+
+            # Load back
+            loaded = manager.load()
+            assert loaded is not None
+            assert loaded.mode == "multi"
+            assert len(loaded.filters) == 1
+            assert loaded.filters[0].name == "filter_1"
+
+    def test_load_old_checkpoint(self):
+        """Loading old single-filter checkpoint should work."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create old-style checkpoint file
+            checkpoint_path = Path(tmpdir) / ".openalex-checkpoint.json"
+            old_data = {
+                "filter_str": "publication_year:>2020",
+                "completed_work_ids": ["W123"],
+                "stats": {"total_downloaded": 1},
+            }
+            checkpoint_path.write_text(json.dumps(old_data))
+
+            manager = CheckpointManager(tmpdir)
+            checkpoint = manager.load()
+            assert checkpoint is not None
+
+            assert checkpoint.mode == "single"
+            assert checkpoint.filter_str == "publication_year:>2020"
+            assert checkpoint.completed_work_ids == {"W123"}
+
+    def test_filter_deduplication_in_checkpoint(self):
+        """Multiple filters with same ID should be deduplicated."""
+        checkpoint = Checkpoint(mode="multi")
+        checkpoint.filters = [
+            FilterCheckpoint(id="same", name="f1", filter_str="a"),
+            FilterCheckpoint(id="same", name="f2", filter_str="b"),
+        ]
+
+        # The checkpoint stores them as-is; deduplication happens in orchestrator
+        assert len(checkpoint.filters) == 2
+        assert checkpoint.filters[0].id == "same"
+        assert checkpoint.filters[1].id == "same"
+
+
+class TestMultiFilterOrchestrator:
+    """Test MultiFilterOrchestrator behavior."""
+
+    def test_orchestrator_init(self):
+        """MultiFilterOrchestrator should initialize with filter list."""
+        from openalex_cli.downloader import MultiFilterOrchestrator
+
+        orchestrator = MultiFilterOrchestrator(
+            api_key="test_key",
+            output_path="/tmp/test",
+            filters=[
+                {"id": "f1", "name": "filter_1", "filter": "year:2024"},
+            ],
+        )
+
+        assert orchestrator.api_key == "test_key"
+        assert len(orchestrator.filters) == 1
+        assert orchestrator.filters[0]["name"] == "filter_1"
+
+    def test_orchestrator_skip_complete_filter(self):
+        """Orchestrator should skip filters marked as complete."""
+        from openalex_cli.downloader import MultiFilterOrchestrator
+        from openalex_cli.checkpoint import CheckpointManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Pre-create checkpoint with completed filter
+            manager = CheckpointManager(tmpdir)
+            checkpoint = manager.create()
+            checkpoint.mode = "multi"
+            checkpoint.filters = [
+                FilterCheckpoint(
+                    id="f1",
+                    name="filter_1",
+                    filter_str="year:2024",
+                    status="complete",
+                )
+            ]
+            manager.force_save()
+
+            orchestrator = MultiFilterOrchestrator(
+                api_key="test_key",
+                output_path=tmpdir,
+                filters=[
+                    {"id": "f1", "name": "filter_1", "filter": "year:2024"},
+                ],
+            )
+
+            # Should not raise when running (filter is skipped)
+            import asyncio
+
+            asyncio.run(orchestrator.run())
+
+    def test_filter_hash_generation(self):
+        """Filter IDs should be based on hash of filter string."""
+        import hashlib
+
+        filter_str = "publication_year:>2020,topics.id:T123"
+        expected_hash = hashlib.sha256(filter_str.encode()).hexdigest()[:8]
+
+        # The orchestrator should generate IDs this way
+        # This is a contract test for the ID generation logic
+        assert len(expected_hash) == 8
+        assert expected_hash.isalnum()

--- a/tests/test_multi_filter.py
+++ b/tests/test_multi_filter.py
@@ -6,6 +6,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from openalex_cli.checkpoint import Checkpoint, CheckpointManager, FilterCheckpoint
 from openalex_cli.downloader import MultiFilterOrchestrator
 
@@ -237,3 +239,87 @@ class TestMultiFilterOrchestrator:
         # This is a contract test for the ID generation logic
         assert len(expected_hash) == 8
         assert expected_hash.isalnum()
+
+
+class TestFilterParsingEdgeCases:
+    """Test edge cases in filter file parsing."""
+
+    def test_duplicate_id_detection(self):
+        """JSON files with duplicate IDs should raise error."""
+        from openalex_cli.filters import _parse_json_file
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_path = Path(tmpdir) / "filters.json"
+            json_path.write_text(
+                json.dumps(
+                    {
+                        "filters": [
+                            {"id": "same_id", "name": "f1", "filter": "year:2024"},
+                            {"id": "same_id", "name": "f2", "filter": "year:2023"},
+                        ]
+                    }
+                )
+            )
+
+            with pytest.raises(ValueError, match="Duplicate filter ID"):
+                _parse_json_file(json_path)
+
+    def test_inline_filter_generation(self):
+        """Inline --filter arguments should generate proper config."""
+        from openalex_cli.filters import _generate_filter_id
+
+        filter_str = "publication_year:>2020"
+        filter_id = _generate_filter_id(filter_str)
+
+        assert len(filter_id) == 8
+        assert filter_id.isalnum()
+        # Same filter should generate same ID
+        assert _generate_filter_id(filter_str) == filter_id
+
+
+class TestOrphanedFilterHandling:
+    """Test orphaned filter detection and cleanup."""
+
+    def test_orphaned_filter_marked_in_checkpoint(self):
+        """Filters in checkpoint but not in config should be marked orphaned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create checkpoint with filter that's not in config
+            manager = CheckpointManager(tmpdir)
+            checkpoint = manager.create()
+            checkpoint.mode = "multi"
+            checkpoint.filters = [
+                FilterCheckpoint(
+                    id="orphan_001",
+                    name="old_filter",
+                    filter_str="year:2022",
+                    status="complete",
+                ),
+                FilterCheckpoint(
+                    id="active_001",
+                    name="current_filter",
+                    filter_str="year:2024",
+                    status="active",
+                ),
+            ]
+            manager.force_save()
+
+            # Create orchestrator with only one filter (orphaning the other)
+            orchestrator = MultiFilterOrchestrator(
+                api_key="test_key",
+                output_path=tmpdir,
+                filters=[
+                    {"id": "active_001", "name": "current_filter", "filter": "year:2024"},
+                ],
+            )
+
+            import asyncio
+
+            asyncio.run(orchestrator.run())
+
+            # Reload and check
+            loaded = manager.load()
+            assert loaded is not None
+            assert len(loaded.filters) == 2
+
+            orphan = next(f for f in loaded.filters if f.id == "orphan_001")
+            assert orphan.status == "orphaned"

--- a/tests/test_page_tracker.py
+++ b/tests/test_page_tracker.py
@@ -1,0 +1,68 @@
+"""Tests for persisted page tracking."""
+
+from openalex_cli.checkpoint import CheckpointManager
+from openalex_cli.page_tracker import PageTracker
+
+
+def test_replay_only_pending_work_after_partial_page_completion(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    page = tracker.register_page("*", "cursor-1", ["W1", "W2", "W3"])
+    tracker.record_work_result(page.seq, "W1", True, 100, 0, None)
+    tracker.record_work_result(page.seq, "W2", False, 0, 0, "boom")
+
+    replay = tracker.replay_pending_work()
+    assert [(item.page_seq, item.work_id) for item in replay] == [(page.seq, "W3")]
+
+
+def test_terminal_pages_commit_in_order_even_if_results_arrive_out_of_order(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    page1 = tracker.register_page("*", "cursor-1", ["W1"])
+    page2 = tracker.register_page("cursor-1", "cursor-2", ["W2"])
+
+    commit = tracker.record_work_result(page2.seq, "W2", True, 20, 0, None)
+    assert commit.committed_pages == 0
+    assert manager.get().current_cursor == "*"
+
+    commit = tracker.record_work_result(page1.seq, "W1", True, 10, 0, None)
+    assert commit.committed_pages == 2
+    assert manager.get().current_cursor == "cursor-2"
+    assert manager.get().pages_completed == 2
+    assert manager.get().completed_work_ids == {"W1", "W2"}
+    assert tracker.replay_pending_work() == []
+
+
+def test_startup_reconcile_drops_stale_committed_manifest(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    page = tracker.register_page("*", "cursor-1", ["W1"])
+    tracker.record_work_result(page.seq, "W1", True, 10, 0, None)
+
+    stale = tracker.register_page("cursor-1", "cursor-2", ["W2"])
+    manifest = tracker.state_store.list_manifests()[0]
+    manifest.work_states["W2"].state = "completed"
+    manifest.work_states["W2"].file_size = 5
+    tracker.state_store.save_manifest(manifest)
+    manager.commit_page("cursor-2", [("W2", 5, 0)], [])
+
+    assert all(item.page_seq != stale.seq for item in tracker.replay_pending_work())
+    tracker.startup_reconcile()
+    assert tracker.replay_pending_work() == []
+
+
+def test_resume_cursor_uses_highest_uncommitted_cursor_out(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+
+    tracker.register_page("*", "cursor-1", ["W1"])
+    tracker.register_page("cursor-1", "cursor-2", ["W2"])
+
+    assert tracker.resume_cursor("*") == "cursor-2"

--- a/tests/test_page_tracker.py
+++ b/tests/test_page_tracker.py
@@ -66,3 +66,27 @@ def test_resume_cursor_uses_highest_uncommitted_cursor_out(tmp_path):
     tracker.register_page("cursor-1", "cursor-2", ["W2"])
 
     assert tracker.resume_cursor("*") == "cursor-2"
+
+
+def test_record_work_result_batches_manifest_flushes(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    manager.create(filter_str="type:article", content_format="none")
+    tracker = PageTracker(tmp_path, manager)
+    tracker.FLUSH_EVERY_RESULTS = 1000
+
+    page = tracker.register_page("*", "cursor-1", ["W1", "W2"])
+    writes: list[int] = []
+
+    original_save = tracker.state_store.save_manifest
+
+    def recording_save(manifest):
+        writes.append(manifest.seq)
+        original_save(manifest)
+
+    tracker.state_store.save_manifest = recording_save
+
+    tracker.record_work_result(page.seq, "W1", True, 10, 0, None)
+    assert writes == []
+
+    tracker.record_work_result(page.seq, "W2", True, 11, 0, None)
+    assert writes == [page.seq]

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,7 +1,5 @@
 """Tests for adaptive rate limiter."""
 
-import asyncio
-
 import pytest
 
 from openalex_cli.rate_limiter import AdaptiveRateLimiter, APIHealth

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -25,8 +25,9 @@ class TestLocalStorage:
 
     async def test_get_full_path(self, storage):
         path = storage.get_full_path("test/file.pdf")
-        assert path.endswith("test/file.pdf")
-        assert Path(path).is_absolute()
+        path_obj = Path(path)
+        assert path_obj.is_absolute()
+        assert path_obj.parts[-2:] == ("test", "file.pdf")
 
     async def test_overwrite_existing(self, storage):
         await storage.save("test.pdf", b"original")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for utility functions."""
 
+from pathlib import Path
+
 import pytest
 
 from openalex_cli.utils import (
@@ -25,15 +27,15 @@ class TestWorkIdToPath:
 
     def test_nested_standard_work_id(self):
         path = work_id_to_path("W2741809807", "pdf", nested=True)
-        assert str(path) == "W27/41/W2741809807.pdf"
+        assert Path(path).parts == ("W27", "41", "W2741809807.pdf")
 
     def test_nested_short_work_id(self):
         path = work_id_to_path("W123", "pdf", nested=True)
-        assert str(path) == "W01/23/W123.pdf"
+        assert Path(path).parts == ("W01", "23", "W123.pdf")
 
     def test_nested_xml_extension(self):
         path = work_id_to_path("W2741809807", "tei.xml", nested=True)
-        assert str(path) == "W27/41/W2741809807.tei.xml"
+        assert Path(path).parts == ("W27", "41", "W2741809807.tei.xml")
 
 
 class TestParseWorkId:
@@ -94,10 +96,7 @@ class TestDoiToFilename:
         assert doi_to_filename("10.1038/nature12373") == "10.1038_nature12373"
 
     def test_doi_with_multiple_slashes(self):
-        assert (
-            doi_to_filename("10.1000/journal.pone.0000000")
-            == "10.1000_journal.pone.0000000"
-        )
+        assert doi_to_filename("10.1000/journal.pone.0000000") == "10.1000_journal.pone.0000000"
 
     def test_doi_with_colon(self):
         assert doi_to_filename("10.1234:example") == "10.1234_example"


### PR DESCRIPTION
# Multi-Filter Download Mode + Checkpoint Safety Consolidation

## Summary

This PR delivers two major feature areas:

1. **Native multi-filter download support** — download works matching multiple filter expressions in a single run, with per-filter state tracking, deduplication, and independent resume
2. **Consolidated prior work** — rolls up Windows signal-handler compatibility, transient 429 retry handling, and metadata-only checkpoint safety redesign with follow-up fixes discovered during real corpus testing

## Feature: Multi-Filter Downloads

### Problem
Users needed to download works matching multiple non-overlapping filter expressions (e.g., different topic IDs, year ranges) into the same output directory. Previously this required multiple CLI invocations, manual deduplication, and fragile checkpoint merging.

### Solution

| Aspect | Before | After |
|--------|--------|-------|
| Filter input | Single `--filter` string only | `--filter` (multiple), `--filters-file` (.txt/.json) |
| Filter configuration | Inline only | `.txt` (one per line, `#` comments), `.json` (structured) |
| Auto-conversion | N/A | `.txt` → `.json` sidecar with metadata |
| Per-filter tracking | N/A | Each filter gets stable hash ID, own cursor, completed/failed sets |
| Deduplication | Manual external scripts | Automatic by work ID across all filters |
| Filter resume | N/A | `--resume-filter "name"` resumes specific filter |
| Stalled recovery | N/A | Auto-retry stalled filters (max 3 attempts) |
| Orphan detection | N/A | Filters removed from config marked `"orphaned"` |
| Validation | None | API preflight validates each filter before download |
| Progress | Single overall bar | Current filter name displayed; per-filter task support |

### CLI Usage

```bash
# Multiple inline filters
openalex download --filter "year:2024,topics:T123" --filter "year:2023,topics:T456" -o ./out

# Filter file (.txt with comments)
openalex download --filters-file filters.txt -o ./out

# Filter file (.json)
openalex download --filters-file filters.json -o ./out

# Resume specific filter
openalex download --filters-file filters.json --resume-filter "filter_001" -o ./out
```

### Implementation

**New files:**
- `src/openalex_cli/filters.py` — filter file parsing, hash ID generation, API validation
- `tests/test_multi_filter.py` — 14 tests for schema, orchestrator, edge cases

**Modified files:**
- `src/openalex_cli/cli.py` — multi-filter CLI options, routing, validation
- `src/openalex_cli/checkpoint.py` — `FilterCheckpoint` dataclass, `mode` field, `retry_count`
- `src/openalex_cli/downloader.py` — `MultiFilterOrchestrator` with hash-based matching, state sync
- `src/openalex_cli/progress.py` — per-filter progress task methods

### Design Decisions

- **Hash-based IDs**: `sha256(filter_str)[:8]` — deterministic, collision-resistant, stable across runs
- **Single checkpoint file**: All per-filter state lives in `.openalex-checkpoint.json` — no separate files
- **First-source-wins deduplication**: Same work ID in multiple filters is downloaded once
- **Checkpoint reload after each filter**: Prevents race condition between parent and child orchestrator

---

## Consolidated Prior Work

### Branches Merged

| Branch | PR | Description |
|--------|-----|-------------|
| `fix/windows-signal-handlers` | — | Windows event loop compatibility |
| `fix/metadata-429-retry` | — | Retry transient 429s for list + metadata |
| `fix/checkpoint-cursor-safety` | #13 | Page-safe metadata-only resume |

### Follow-Up Fixes (discovered during real-corpus testing)

| Issue | Root Cause | Fix |
|-------|-----------|-----|
| `PermissionError` on Windows | `os.replace()` failing during manifest rewrite | Bounded retry around atomic replace |
| Slow replay (~2.5 files/s) | Excessive manifest disk I/O during replay | In-memory cache + batched flushing |
| Failed IDs not retried | No built-in retry mechanism | `--retry-failed` + `--retry-workers` phase |
| Progress stuck at 0% | No total work count available | One-shot preflight count request |
| Progress > 100% | Session counters mixed with checkpoint truth | Authoritative checkpoint-based progress |
| Retry shows 100 workers | Retry phase reused main rate limiter | Retry-specific `AdaptiveRateLimiter` |
| "558 failed" after retry success | `stats.total_failed` used instead of unresolved count | Separate unresolved vs historical failure reporting |

### Checkpoint Safety (from #13)

| Concern | Before | After |
|---------|--------|-------|
| Page membership | Only in memory after queue admission | Persisted in local page manifests |
| Cursor advancement | When page was listed and queued | Only after page becomes terminal |
| Interrupted resume | Could silently omit unfinished works | Replays unfinished work before fresh pagination |
| Page state durability | None | Atomic temp-file + fsync + replace |

### Files Changed (since upstream main)

```
src/openalex_cli/api_client.py        | 180  +++++++++++++++---
src/openalex_cli/checkpoint.py       | 154  ++++++++++++++-
src/openalex_cli/cli.py              | 152  ++++++++++++++-
src/openalex_cli/downloader.py       | 634  ++++++++++++++++++++++++++++++---
src/openalex_cli/fault_injection.py  |  58  +++++
src/openalex_cli/filters.py          | 230  ++++++++++++++++
src/openalex_cli/page_tracker.py     | 318  ++++++++++++++++
src/openalex_cli/progress.py         | 121  ++++++++-  
src/openalex_cli/rate_limiter.py     |   6 +-
src/openalex_cli/state_io.py         |  61  +++++
src/openalex_cli/storage/__init__.py |   8 +-
src/openalex_cli/storage/local.py    |   3 +-
src/openalex_cli/storage/s3.py       |   6 +-
src/openalex_cli/utils.py            |  11 +-
tests/test_api_client.py             |  55  +++++
tests/test_checkpoint.py             |  66  +++++-
tests/test_downloader.py             | 870  ++++++++++++++++++++++++++++++++++++
tests/test_list_retry.py             | 141  ++++++++
tests/test_multi_filter.py           | 325  +++++++++++++++++++++
tests/test_page_tracker.py           |  92  ++++++
tests/test_rate_limiter.py           |   2 -
tests/test_storage.py                |   5 +-
tests/test_utils.py                  |  13 +-
23 files changed, 3235 insertions(+), 190 deletions(-)
```

### Quality Gates

```powershell
$env:PYTHONPATH='src'; python -m ruff check src tests
$env:PYTHONPATH='src'; python -m mypy src
$env:PYTHONPATH='src'; pytest
```

| Gate | Result |
|------|--------|
| ruff | ✅ passed |
| mypy | ✅ passed (16 files, 0 errors) |
| pytest | ✅ passed (97 tests) |

---

## Scope & Non-Goals

**In scope:**
- Metadata-only downloads (standard cursor pagination)
- Multi-filter mode with `.txt`/`.json` input
- Per-filter resume, retry, and progress
- Windows compatibility for signal handling
- Transient 429 retry for list + metadata endpoints
- Page-safe checkpoint resume for metadata-only
- Automatic failed-ID retry phase
- Real progress from startup count preflight

**Not in scope:**
- Content-mode (PDF/XML/BOTH) page tracking
- Sample-mode replay semantics
- Explicit-ID list page tracking
- Concurrent multi-instance safety (documented: don't run multiple instances on same dir)
